### PR TITLE
Shorten tag for web-bot-auth crate for publication

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2024"
 readme = "README.md"
 homepage = "https://github.com/cloudflare/web-bot-auth"
 repository = "https://github.com/cloudflare/web-bot-auth"
-keywords = ["web-bot-auth", "http-message-signatures", "rfc9421", "cryptography"]
+keywords = ["web-bot-auth", "http-signatures", "message-signatures", "rfc9421", "cryptography"]
 categories = ["cryptography"]
 license = "Apache-2.0"
 


### PR DESCRIPTION
Crates.io allows tag below 20 characters only. This fixes it.