### PR TITLE
Make all public structs cloneable, except for ImplementationError

### DIFF
--- a/crates/web-bot-auth/src/components.rs
+++ b/crates/web-bot-auth/src/components.rs
@@ -5,7 +5,7 @@
 use super::ImplementationError;
 
 /// [Signature component parameters](https://www.rfc-editor.org/rfc/rfc9421#name-http-signature-component-pa) for HTTP fields.
-#[derive(Debug, PartialEq, Hash, Eq)]
+#[derive(Clone, Debug, PartialEq, Hash, Eq)]
 pub enum HTTPFieldParameters {
     /// Indicates whether this HTTP header was both a structured field value and should be strictly serialized in its
     /// signature base representation.
@@ -24,11 +24,11 @@ pub enum HTTPFieldParameters {
 
 /// A container that represents an ordered list of signature component fields. Order is significant during signing and
 /// verifying.
-#[derive(Debug, PartialEq, Hash, Eq)]
+#[derive(Clone, Debug, PartialEq, Hash, Eq)]
 pub struct HTTPFieldParametersSet(pub Vec<HTTPFieldParameters>);
 
 /// Represents an HTTP header, informally.
-#[derive(Debug, PartialEq, Hash, Eq)]
+#[derive(Clone, Debug, PartialEq, Hash, Eq)]
 pub struct HTTPField {
     /// Uniquely identified by name
     pub name: String,
@@ -233,7 +233,7 @@ impl TryFrom<HTTPField> for sfv::Item {
 
 /// [Signature component parameters](https://www.rfc-editor.org/rfc/rfc9421#name-http-signature-component-pa)
 /// specifically for the `@query-params` derived component.
-#[derive(Debug, PartialEq, Hash, Eq)]
+#[derive(Clone, Debug, PartialEq, Hash, Eq)]
 pub enum QueryParamParameters {
     /// Unique identifier for the query param
     Name(String),
@@ -244,7 +244,7 @@ pub enum QueryParamParameters {
 /// A list of derived components, used to specify attributes of an HTTP message that otherwise can't be referenced
 /// via an HTTP header but nevertheless can be used in generating a signature base. Each component here, with the sole
 /// exception of `QueryParameters`, accepts a single component parameter `req.
-#[derive(Debug, PartialEq, Hash, Eq)]
+#[derive(Clone, Debug, PartialEq, Hash, Eq)]
 pub enum DerivedComponent {
     /// Represents `@authority` derived component
     Authority {
@@ -295,7 +295,7 @@ pub enum DerivedComponent {
 
 /// A container that represents an ordered list of signature component fields. Order is significant during signing and
 /// verifying.
-#[derive(Debug, PartialEq, Hash, Eq)]
+#[derive(Clone, Debug, PartialEq, Hash, Eq)]
 pub struct QueryParamParametersSet(pub Vec<QueryParamParameters>);
 
 impl TryFrom<sfv::Parameters> for QueryParamParametersSet {
@@ -451,7 +451,7 @@ impl TryFrom<DerivedComponent> for sfv::Item {
 
 /// Represents *any* component that can be used during message signing or verifying. See documentation
 /// about each wrapped variant to learn more.
-#[derive(Debug, PartialEq, Hash, Eq)]
+#[derive(Clone, Debug, PartialEq, Hash, Eq)]
 pub enum CoveredComponent {
     /// Represents an HTTP field that can be used as part of the `Signature-Input` field
     HTTP(HTTPField),

--- a/crates/web-bot-auth/src/lib.rs
+++ b/crates/web-bot-auth/src/lib.rs
@@ -90,14 +90,14 @@ pub enum WebBotAuthError {
     NotImplemented,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 struct SignatureParams {
     raw: sfv::Parameters,
     details: ParameterDetails,
 }
 
 /// Parsed values from `Signature-Input` header.
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 pub struct ParameterDetails {
     /// The value of the `alg` parameter, if present and resolves to a known algorithm.
     pub algorithm: Option<Algorithm>,
@@ -201,7 +201,7 @@ impl SignatureBaseBuilder {
 }
 
 /// A representation of the signature base to be generated during verification and signing.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 struct SignatureBase {
     components: IndexMap<CoveredComponent, String>,
     parameters: SignatureParams,
@@ -268,7 +268,7 @@ impl SignatureBase {
 
 /// Subset of [HTTP signature algorithm](https://www.iana.org/assignments/http-message-signature/http-message-signature.xhtml)
 /// implemented in this module. In the future, we may support more.
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 pub enum Algorithm {
     /// [The `ed25519` algorithm](https://www.rfc-editor.org/rfc/rfc9421#name-eddsa-using-curve-edwards25)
     Ed25519,
@@ -447,14 +447,14 @@ impl MessageSigner {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 struct ParsedLabel {
     signature: Vec<u8>,
     base: SignatureBase,
 }
 
 /// A `MessageVerifier` performs the verifications needed for a signed message.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct MessageVerifier {
     parsed: ParsedLabel,
     algorithm: Algorithm,
@@ -462,6 +462,7 @@ pub struct MessageVerifier {
 
 /// Micro-measurements of different parts of the process in a call to `verify()`.
 /// Useful for measuring overhead.
+#[derive(Clone, Debug)]
 pub struct SignatureTiming {
     /// Time taken to generate a signature base,
     pub generation: Duration,
@@ -637,7 +638,7 @@ pub trait WebBotAuthSignedMessage: SignedMessage {
 }
 
 /// A verifier for Web Bot Auth messages specifically.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct WebBotAuthVerifier {
     message_verifier: MessageVerifier,
     /// The value of `Signature-Agent` header, if resolved to a link


### PR DESCRIPTION
This is a minor quality-of-life improvement to make it easy to embed these structs in wrappers that implement `Clone()`. It came up during tests, for example, that would be greatly simplified if a covered component could be `Cloned`.

`ImplementationError` cannot be `Clone()`d because `sfv::Error` is not cloneable.