### PR TITLE
Revert bump to major version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "rust-examples"
-version = "0.1.0"
+version = "0.0.3"
 dependencies = [
  "indexmap",
  "web-bot-auth",
@@ -400,7 +400,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "web-bot-auth"
-version = "0.1.0"
+version = "0.0.3"
 dependencies = [
  "base64",
  "data-url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.0.3"
 authors = [
     "Akshat Mahajan <akshat@cloudflare.com>",
     "Gauri Baraskar <gbaraskar@cloudflare.com>",
@@ -32,4 +32,4 @@ serde_json = "1.0.140"
 data-url = "0.3.1"
 
 # workspace dependencies
-web-bot-auth = { version = "0.1.0", path = "./crates/web-bot-auth" }
+web-bot-auth = { version = "0.0.3", path = "./crates/web-bot-auth" }


### PR DESCRIPTION
It turns out we still need to support multiple `Signature` and `Signature-Input` headers. Until then, this can't be a full API.