### PR TITLE
Add signature with each key for directory responses

### DIFF
--- a/examples/browser-extension/scripts/build_web_artifacts.mjs
+++ b/examples/browser-extension/scripts/build_web_artifacts.mjs
@@ -17,10 +17,10 @@ import * as fs from "node:fs";
 import path from "node:path";
 const { KeyObject } = await import("node:crypto");
 const { subtle } = globalThis.crypto;
-import pkg from '../package.json' with { type: "json" };
+import pkg from "../package.json" with { type: "json" };
 
 function makePolicy(extensionID) {
-  const MarkerString = "EXTENSION_ID_REPLACED_BY_NPM_RUN_BUNDLE_CHROME"
+  const MarkerString = "EXTENSION_ID_REPLACED_BY_NPM_RUN_BUNDLE_CHROME";
   const policyPath = path.join(path.dirname("."), "policy");
   if (!fs.existsSync(policyPath)) {
     fs.mkdirSync(policyPath, { recursive: true });
@@ -37,8 +37,20 @@ function makePolicy(extensionID) {
 }
 
 function setManifestVersion(version) {
-  const manifestInputPath = path.join(path.dirname("."), "platform", "mv3", "chromium", 'manifest.json');
-  const manifestOutputPath = path.join(path.dirname("."), "dist", "mv3", "chromium", 'manifest.json');
+  const manifestInputPath = path.join(
+    path.dirname("."),
+    "platform",
+    "mv3",
+    "chromium",
+    "manifest.json"
+  );
+  const manifestOutputPath = path.join(
+    path.dirname("."),
+    "dist",
+    "mv3",
+    "chromium",
+    "manifest.json"
+  );
   const manifestStr = fs.readFileSync(manifestInputPath, "utf8");
   const manifest = JSON.parse(manifestStr);
   manifest.version = version;
@@ -72,22 +84,22 @@ async function main() {
   });
 
   const crx = new ChromeExtension({
-    codebase: "http://localhost:8000/" + pkg.name + '.crx',
+    codebase: "http://localhost:8000/" + pkg.name + ".crx",
     privateKey: skPEM,
     publicKey: pkBytes,
   });
 
   setManifestVersion(pkg.version);
-  await crx.load(path.join(path.dirname("."), "dist", "mv3", "chromium"))
+  await crx.load(path.join(path.dirname("."), "dist", "mv3", "chromium"));
   const extensionBytes = await crx.pack();
   const extensionID = crx.generateAppId();
 
   fs.writeFileSync("private_key.pem", skPEM);
-  fs.writeFileSync(path.join(distPath, pkg.name + '.crx'), extensionBytes);
+  fs.writeFileSync(path.join(distPath, pkg.name + ".crx"), extensionBytes);
   fs.writeFileSync(path.join(distPath, "update.xml"), crx.generateUpdateXML());
   makePolicy(extensionID);
 
-  console.log(`Build Extension with ID: ${extensionID}`)
-};
+  console.log(`Build Extension with ID: ${extensionID}`);
+}
 
 await main();

--- a/packages/http-message-sig/src/consts.ts
+++ b/packages/http-message-sig/src/consts.ts
@@ -1,6 +1,10 @@
 export const HTTP_MESSAGE_SIGNATURES_DIRECTORY =
-  "./well-known/http-message-signatures-directory";
+  "/.well-known/http-message-signatures-directory";
 
 export enum MediaType {
   HTTP_MESSAGE_SIGNATURES_DIRECTORY = "application/http-message-signatures-directory",
+}
+
+export enum Tag {
+  HTTP_MESSAGE_SIGNAGURES_DIRECTORY = "http-message-signatures-directory",
 }

--- a/packages/http-message-sig/src/directory.ts
+++ b/packages/http-message-sig/src/directory.ts
@@ -1,0 +1,59 @@
+import { Tag } from "./consts";
+import { signatureHeaders } from "./sign";
+import { Component, RequestLike, SignatureHeaders, Signer } from "./types";
+
+export const RESPONSE_COMPONENTS: Component[] = ["@authority"];
+
+export interface SignatureParams {
+  created: Date;
+  expires: Date;
+}
+
+export async function directoryResponseHeaders<T1 extends RequestLike>(
+  request: T1, // request is used to derive @authority for the response
+  signers: Signer[],
+  params: SignatureParams
+): Promise<SignatureHeaders> {
+  if (params.created.getTime() > params.expires.getTime()) {
+    throw new Error("created should happen before expires");
+  }
+
+  // TODO: consider validating the directory structure, and confirm we have one signer per key
+
+  const components: string[] = RESPONSE_COMPONENTS;
+
+  const headers = new Map<string, SignatureHeaders>();
+
+  for (let i = 0; i < signers.length; i += 1) {
+    // eslint-disable-next-line security/detect-object-injection
+    const signer = signers[i];
+    if (headers.has(signer.keyid)) {
+      throw new Error(`Duplicated signer with keyid ${signer.keyid}`);
+    }
+
+    headers.set(
+      signer.keyid,
+      await signatureHeaders(request, {
+        signer,
+        components,
+        created: params.created,
+        expires: params.expires,
+        keyid: signer.keyid,
+        key: `binding${i}`,
+        tag: Tag.HTTP_MESSAGE_SIGNAGURES_DIRECTORY,
+      })
+    );
+  }
+
+  const SF_SEPARATOR = ", ";
+  // Providing multiple signature as described in Section 4.3 of RFC 9421
+  // https://datatracker.ietf.org/doc/html/rfc9421#name-multiple-signatures
+  return {
+    Signature: Array.from(headers.values())
+      .map((h) => h.Signature)
+      .join(SF_SEPARATOR),
+    "Signature-Input": Array.from(headers.values())
+      .map((h) => h["Signature-Input"])
+      .join(SF_SEPARATOR),
+  };
+}

--- a/packages/http-message-sig/src/index.ts
+++ b/packages/http-message-sig/src/index.ts
@@ -1,6 +1,7 @@
 export * as base64 from "./base64";
 export { extractHeader } from "./build";
 export * from "./consts";
+export * from "./directory";
 export { parseAcceptSignatureHeader as parseAcceptSignature } from "./parse";
 export * from "./sign";
 export * from "./types";

--- a/packages/web-bot-auth/src/index.ts
+++ b/packages/web-bot-auth/src/index.ts
@@ -6,6 +6,8 @@ export {
   type SignatureHeaders,
   type Signer,
   type SignerSync,
+  Tag,
+  directoryResponseHeaders,
 } from "http-message-sig";
 export { jwkThumbprint as jwkToKeyID } from "jsonwebkey-thumbprint";
 


### PR DESCRIPTION
This adds a method to http-message-sig package so that directory responses can be signed as recommended in the draft. The draft change is pending and available in https://github.com/thibmeu/http-message-signatures-directory/pull/40

This commit also updates the example worker to provide a signature over the directory.

Tests are to be added. They could also serve as a basis to get test vectors in the directory draft.

If needed, this commit can be deployed to a test domain @AkshataDM 

When running `npm run start` locally, I get

```
$ http http://localhost:8787/.well-known/http-message-signatures-directory
HTTP/1.1 200 OK
Content-Length: 178
Content-Type: application/http-message-signatures-directory
Signature: binding0=:i23cuESh2w4oCNrD+TgsaJXDQf2big85jY3aPV0VTSkZaPQvxqMM6j9r8A3i/D2yzl+lDuDbxrWBlwnUciSkAA==:
Signature-Input: binding0=("@authority");created=1749805161;keyid="poqkLGiymh_W0uP6PZFw-dvez3QJT5SolqXBCW38r0U";alg="ed25519";expires=1749805461;tag="http-message-signatures-directory"

{"keys":[{"kid":"poqkLGiymh_W0uP6PZFw-dvez3QJT5SolqXBCW38r0U","kty":"OKP","crv":"Ed25519","x":"JrQLj5P_89iXES9-vFgrIy29clF9CC_oPPsw3c5D0bs","nbf":1743465600000}],"purpose":"rag"}
```