### PR TITLE
Fix a confusing type parameter for generating signatures.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "rust-examples"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "indexmap",
  "web-bot-auth",
@@ -400,7 +400,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "web-bot-auth"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "base64",
  "data-url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 authors = [
     "Akshat Mahajan <akshat@cloudflare.com>",
     "Gauri Baraskar <gbaraskar@cloudflare.com>",
@@ -32,4 +32,4 @@ serde_json = "1.0.140"
 data-url = "0.3.1"
 
 # workspace dependencies
-web-bot-auth = { version = "0.1.0", path = "./crates/web-bot-auth" }
+web-bot-auth = { version = "0.1.1", path = "./crates/web-bot-auth" }

--- a/crates/web-bot-auth/src/message_signatures.rs
+++ b/crates/web-bot-auth/src/message_signatures.rs
@@ -1,5 +1,5 @@
 use crate::components::CoveredComponent;
-use crate::keyring::{KeyRing, PublicKey};
+use crate::keyring::KeyRing;
 use indexmap::IndexMap;
 use sfv::SerializeValue;
 use std::fmt;
@@ -292,7 +292,7 @@ impl MessageSigner {
         &self,
         message: &mut impl UnsignedMessage,
         expires: Duration,
-        signing_key: &PublicKey,
+        signing_key: &Vec<u8>,
     ) -> Result<(), ImplementationError> {
         let components_to_cover = message.fetch_components_to_cover();
         let mut sfv_parameters = sfv::Parameters::new();


### PR DESCRIPTION
The `generate_signature_headers_content` method's `signing_key`
argument references `PublicKey` as its type. That's semantically wrong -
a signing key must be a private key. In this case, `PublicKey` is a type
alias for `Vec<u8>`, which is why it works - but there's no reason for
us to confuse the public. I have removed the `PublicKey` and replaced it
directly with `Vec<u8>`, and bumped Cargo accordingly per semver.