### PR TITLE
Update content-type to follow specification

### DIFF
--- a/packages/http-message-sig/src/consts.ts
+++ b/packages/http-message-sig/src/consts.ts
@@ -2,7 +2,7 @@ export const HTTP_MESSAGE_SIGNATURES_DIRECTORY =
   "/.well-known/http-message-signatures-directory";
 
 export enum MediaType {
-  HTTP_MESSAGE_SIGNATURES_DIRECTORY = "application/http-message-signatures-directory",
+  HTTP_MESSAGE_SIGNATURES_DIRECTORY = "application/http-message-signatures-directory+json",
 }
 
 export enum Tag {


### PR DESCRIPTION
Content type in the latest draft has been updated to have `+json`

https://thibmeu.github.io/http-message-signatures-directory/draft-meunier-http-message-signatures-directory.html#name-application-http-message-si