### PR TITLE
Drop requiring `alg` to be present on the message + enhancements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -572,7 +572,7 @@ dependencies = [
 
 [[package]]
 name = "http-signature-directory"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "clap",
  "env_logger",
@@ -1183,7 +1183,7 @@ dependencies = [
 
 [[package]]
 name = "rust-examples"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "indexmap",
  "web-bot-auth",
@@ -1774,7 +1774,7 @@ dependencies = [
 
 [[package]]
 name = "web-bot-auth"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "base64",
  "data-url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.2.1"
+version = "0.3.0"
 authors = [
     "Akshat Mahajan <akshat@cloudflare.com>",
     "Gauri Baraskar <gbaraskar@cloudflare.com>",
@@ -32,4 +32,4 @@ serde_json = "1.0.140"
 data-url = "0.3.1"
 
 # workspace dependencies
-web-bot-auth = { version = "0.2.1", path = "./crates/web-bot-auth" }
+web-bot-auth = { version = "0.3.0", path = "./crates/web-bot-auth" }

--- a/crates/http-signature-directory/src/main.rs
+++ b/crates/http-signature-directory/src/main.rs
@@ -12,7 +12,7 @@ use reqwest::{
 use web_bot_auth::{
     components::{CoveredComponent, DerivedComponent},
     keyring::{JSONWebKeySet, KeyRing, Thumbprintable},
-    message_signatures::{Algorithm, MessageVerifier, SignedMessage},
+    message_signatures::{MessageVerifier, SignedMessage},
 };
 
 const MIME_TYPE: &str = "application/http-message-signatures-directory+json";
@@ -148,7 +148,6 @@ fn main() -> Result<(), String> {
 
                 let verifier = MessageVerifier::parse(
                     &directory,
-                    Some(Algorithm::Ed25519),
                     |(_, innerlist)| {
                         innerlist.params.contains_key("expires")
                             && innerlist.params.contains_key("created")
@@ -158,13 +157,6 @@ fn main() -> Result<(), String> {
                                 .and_then(|tag| tag.as_string())
                                 .is_some_and(|tag| {
                                     tag.as_str() == "http-message-signatures-directory"
-                                })
-                            && innerlist
-                                .params
-                                .get("alg")
-                                .and_then(|tag| tag.as_string())
-                                .is_some_and(|tag| {
-                                    tag.as_str() == "ed25519"
                                 })
                             && innerlist
                                 .params

--- a/examples/rust/signing.rs
+++ b/examples/rust/signing.rs
@@ -16,7 +16,8 @@ use indexmap::IndexMap;
 use std::{time::Duration, vec};
 use web_bot_auth::{
     components::{CoveredComponent, DerivedComponent, HTTPField, HTTPFieldParametersSet},
-    message_signatures::{Algorithm, MessageSigner, UnsignedMessage},
+    keyring::Algorithm,
+    message_signatures::{MessageSigner, UnsignedMessage},
 };
 
 #[derive(Debug, Default)]
@@ -56,14 +57,18 @@ fn main() {
         0x29, 0xc5,
     ];
     let signer = MessageSigner {
-        algorithm: Algorithm::Ed25519,
         keyid: "poqkLGiymh_W0uP6PZFw-dvez3QJT5SolqXBCW38r0U".into(),
         nonce: "ZO3/XMEZjrvSnLtAP9M7jK0WGQf3J+pbmQRUpKDhF9/jsNCWqUh2sq+TH4WTX3/GpNoSZUa8eNWMKqxWp2/c2g==".into(),
         tag: "web-bot-auth".into(),
     };
     let mut headers = MyThing::default();
     signer
-        .generate_signature_headers_content(&mut headers, Duration::from_secs(10), &private_key)
+        .generate_signature_headers_content(
+            &mut headers,
+            Duration::from_secs(10),
+            Algorithm::Ed25519,
+            &private_key,
+        )
         .unwrap();
 
     assert!(!headers.signature_input.is_empty());

--- a/examples/rust/verify.rs
+++ b/examples/rust/verify.rs
@@ -15,7 +15,7 @@
 use web_bot_auth::{
     SignatureAgentLink, WebBotAuthSignedMessage, WebBotAuthVerifier,
     components::{CoveredComponent, DerivedComponent, HTTPField},
-    keyring::KeyRing,
+    keyring::{Algorithm, KeyRing},
     message_signatures::SignedMessage,
 };
 
@@ -60,10 +60,11 @@ fn main() {
     let mut keyring = KeyRing::default();
     keyring.import_raw(
         "poqkLGiymh_W0uP6PZFw-dvez3QJT5SolqXBCW38r0U".to_string(),
+        Algorithm::Ed25519,
         public_key.to_vec(),
     );
     let test = MySignedMsg {};
-    let verifier = WebBotAuthVerifier::parse(&test, None).unwrap();
+    let verifier = WebBotAuthVerifier::parse(&test).unwrap();
     let advisory = verifier.get_details().possibly_insecure(|_| false);
     for url in verifier.get_signature_agents().iter() {
         assert_eq!(

--- a/examples/rust/verify_arbitrary.rs
+++ b/examples/rust/verify_arbitrary.rs
@@ -14,7 +14,7 @@
 
 use web_bot_auth::{
     components::{CoveredComponent, DerivedComponent},
-    keyring::KeyRing,
+    keyring::{Algorithm, KeyRing},
     message_signatures::{MessageVerifier, SignedMessage},
 };
 
@@ -47,10 +47,11 @@ fn main() {
     let mut keyring = KeyRing::default();
     keyring.import_raw(
         "poqkLGiymh_W0uP6PZFw-dvez3QJT5SolqXBCW38r0U".to_string(),
+        Algorithm::Ed25519,
         public_key.to_vec(),
     );
     let test = MySignedMsg {};
-    let verifier = MessageVerifier::parse(&test, None, |_| true).unwrap();
+    let verifier = MessageVerifier::parse(&test, |_| true).unwrap();
     let advisory = verifier.get_details().possibly_insecure(|_| false);
     // Since the expiry date is in the past.
     assert!(advisory.is_expired.unwrap_or(true));


### PR DESCRIPTION
`alg` is discouraged owing to the possibility of key downgrade attacks in [RFC 9421](https://www.rfc-editor.org/rfc/rfc9421.html#name-key-and-algorithm-specifica). Previous incarnations of this crate assumed that `alg` would either be present in the message or supplied externally. This change instead requires the *keyring* to remember which algorithm a key corresponds to during verification, meaning we no longer trust the message's use of `alg`.

The change involves a few places:

1. `KeyRing` is now a hashmap from key IDs to algorithms and public keys, rather than just public keys. In the long term, we should move these fields to a dedicated `KeyAndMetadata` struct.

2. `Algorithm` has been extended to support all known algorithms per the IANA list. However, we will continue to only support importing ed25519 keys in the keyring. If the community needs this, people can add support. Similarly, we will not attempt to verify or sign a message for non-ed25519 keys just now.

I've additionally dropped `alg` being required on the HTTP signature directory.

I've also lumped in a feature request I received internally: the ability to inspect the message components in the signature base. I did this by making `ParsedLabel` public, as well as `SignatureBase`. They were not public previously since I surmised people would find more value in these details being opaque - but there's no serious reason they need to be private. It also means we don't need to needlessly clone `ParameterDetails`.