### PR TITLE
Expose the parsed label, rather than just the parameters, to the public

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -572,7 +572,7 @@ dependencies = [
 
 [[package]]
 name = "http-signature-directory"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "clap",
  "env_logger",
@@ -1183,7 +1183,7 @@ dependencies = [
 
 [[package]]
 name = "rust-examples"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "indexmap",
  "web-bot-auth",
@@ -1774,7 +1774,7 @@ dependencies = [
 
 [[package]]
 name = "web-bot-auth"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64",
  "data-url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 authors = [
     "Akshat Mahajan <akshat@cloudflare.com>",
     "Gauri Baraskar <gbaraskar@cloudflare.com>",
@@ -32,4 +32,4 @@ serde_json = "1.0.140"
 data-url = "0.3.1"
 
 # workspace dependencies
-web-bot-auth = { version = "0.3.0", path = "./crates/web-bot-auth" }
+web-bot-auth = { version = "0.4.0", path = "./crates/web-bot-auth" }

--- a/crates/http-signature-directory/src/main.rs
+++ b/crates/http-signature-directory/src/main.rs
@@ -175,7 +175,12 @@ fn main() -> Result<(), String> {
                     )
                 })?;
 
-                let advisory = verifier.get_details().possibly_insecure(|_| false);
+                let advisory = verifier
+                    .parsed
+                    .base
+                    .parameters
+                    .details
+                    .possibly_insecure(|_| false);
                 // Since the expiry date is in the past.
                 if advisory.is_expired.unwrap_or(true) {
                     return Err(String::from(

--- a/crates/web-bot-auth/src/message_signatures.rs
+++ b/crates/web-bot-auth/src/message_signatures.rs
@@ -10,7 +10,8 @@ use super::ImplementationError;
 /// The component parameters associated with the signature in `Signature-Input`
 #[derive(Clone, Debug)]
 pub struct SignatureParams {
-    raw: sfv::Parameters,
+    /// The raw signature parameters associated with this request.
+    pub raw: sfv::Parameters,
     /// Standard values obtained from the component parameters, such as created, etc.
     pub details: ParameterDetails,
 }
@@ -484,12 +485,6 @@ impl MessageVerifier {
         Ok(MessageVerifier {
             parsed: ParsedLabel { signature, base },
         })
-    }
-
-    /// Retrieve the parsed `ParameterDetails` from the message. Useful for logging
-    /// information about the message.
-    pub fn get_details(&self) -> &ParameterDetails {
-        &self.parsed.base.parameters.details
     }
 
     /// Verify the messsage, consuming the verifier in the process.

--- a/examples/rust/verify.rs
+++ b/examples/rust/verify.rs
@@ -65,7 +65,12 @@ fn main() {
     );
     let test = MySignedMsg {};
     let verifier = WebBotAuthVerifier::parse(&test).unwrap();
-    let advisory = verifier.get_details().possibly_insecure(|_| false);
+    let advisory = verifier
+        .get_parsed_label()
+        .base
+        .parameters
+        .details
+        .possibly_insecure(|_| false);
     for url in verifier.get_signature_agents().iter() {
         assert_eq!(
             url,

--- a/examples/rust/verify_arbitrary.rs
+++ b/examples/rust/verify_arbitrary.rs
@@ -52,7 +52,12 @@ fn main() {
     );
     let test = MySignedMsg {};
     let verifier = MessageVerifier::parse(&test, |_| true).unwrap();
-    let advisory = verifier.get_details().possibly_insecure(|_| false);
+    let advisory = verifier
+        .parsed
+        .base
+        .parameters
+        .details
+        .possibly_insecure(|_| false);
     // Since the expiry date is in the past.
     assert!(advisory.is_expired.unwrap_or(true));
     assert!(!advisory.nonce_is_invalid.unwrap_or(true));


### PR DESCRIPTION
Systems need to be able to log aspects of the message that was received.

Previously, we only exposed `ParameterDetails`, which were sufficient for logging a select few properties found in the message. However, there's more value in exposing the contents of the chosen Signature and Signature-Input label, allowing people to view the raw signature, as well as the signed components in the message, so as to enforce their own requirements.

This change drops exposing `ParameterDetails` directly and instead exposes `ParsedLabel`, which both allows access to `ParameterDetails` and additionally exposes the signature components and the signature itself.