### PR TITLE
Add validated keys to the output

### DIFF
--- a/crates/http-signature-directory/README.md
+++ b/crates/http-signature-directory/README.md
@@ -55,12 +55,18 @@ $ RUST_LOG=debug http-signature-directory https://http-message-signatures-exampl
         "thumbprint": "poqkLGiymh_W0uP6PZFw-dvez3QJT5SolqXBCW38r0U",
         "valid": true,
         "signature_verified": true,
+        "raw_key_data": {
+          "kty": "OKP",
+          "crv": "Ed25519",
+          "x": "JrQLj5P_89iXES9-vFgrIy29clF9CC_oPPsw3c5D0bs"
+        },
         "error": null
       }
     ],
     "errors": [],
     "warnings": []
   }
+}
 ```
 
 ## Security Considerations

--- a/crates/http-signature-directory/src/main.rs
+++ b/crates/http-signature-directory/src/main.rs
@@ -46,7 +46,15 @@ struct KeyValidationInfo {
     thumbprint: String,
     valid: bool, // Checks if the key structure is valid (correct key type, curve is Ed25519, import succeeds)
     signature_verified: bool, // Checks if the HTTP signature on the directory response is cryptographically valid using this key
+    raw_key_data: Option<RawKeyData>,
     error: Option<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct RawKeyData {
+    kty: String,
+    crv: String,
+    x: String,
 }
 
 struct SignedDirectory {
@@ -219,6 +227,7 @@ fn main() -> Result<(), String> {
             thumbprint: thumbprint.clone(),
             valid: false,
             signature_verified: false,
+            raw_key_data: None,
             error: None,
         };
 
@@ -278,6 +287,11 @@ fn main() -> Result<(), String> {
                                 match verifier.verify(&keyring, None) {
                                     Ok(_) => {
                                         key_info.signature_verified = true;
+                                        key_info.raw_key_data = Some(RawKeyData {
+                                            kty: "OKP".to_string(),
+                                            crv: crv.to_string(),
+                                            x: x.to_string(),
+                                        });
                                     }
                                     Err(err) => {
                                         key_info.error = Some(format!(


### PR DESCRIPTION
Small changes to add validated keys to the output so that extraction and validation can be combined.