### PR TITLE
[WIP] Fix Typescript implementation as path has to be normalised

### DIFF
--- a/packages/http-message-sig/src/build.ts
+++ b/packages/http-message-sig/src/build.ts
@@ -26,11 +26,15 @@ export function getUrl(
     const host = extractHeader(message, "host");
     const protocol = message.protocol || "http";
     const baseUrl = `${protocol}://${host}`;
-    return new URL(message.url, baseUrl);
+    const url = new URL(message.url, baseUrl);
+    url.pathname = decodeURIComponent(url.pathname);
+    return new URL(url.href);
   }
   if (!(message as RequestLike).url)
     throw new Error(`${component} is only valid for requests`);
-  return new URL((message as RequestLike).url);
+  const url = new URL((message as RequestLike).url);
+  url.pathname = decodeURIComponent(url.pathname);
+  return new URL(url.href);
 }
 
 // see https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-message-signatures-06#section-2.3

--- a/packages/http-message-sig/test/build.spec.ts
+++ b/packages/http-message-sig/test/build.spec.ts
@@ -110,11 +110,11 @@ describe("build", () => {
       const result = extractComponent(
         {
           method: "POST",
-          url: "https://www.example.com/path?param=value",
+          url: "https://www.example.com/%7epath?param=value",
         } as unknown as RequestLike,
         "@path"
       );
-      expect(result).to.equal("/path");
+      expect(result).to.equal("/~path");
     });
 
     it("correctly extracts the @query", () => {


### PR DESCRIPTION
per [RFC 9421 section 2.2.6](https://datatracker.ietf.org/doc/html/rfc9421#name-path)

This actually applies to other components, so I've put this PR on hold.

I've added a regression test as well.