### PR TITLE
Enforce normalization rules during signing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -987,9 +987,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
@@ -1780,6 +1780,7 @@ dependencies = [
  "data-url",
  "ed25519-dalek",
  "indexmap",
+ "percent-encoding",
  "serde",
  "serde_json",
  "sfv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ sha2 = "0.10.9"
 base64 = "0.22.1"
 serde_json = "1.0.140"
 data-url = "0.3.1"
+percent-encoding = "2.3.2"
 
 # workspace dependencies
 web-bot-auth = { version = "0.5.0", path = "./crates/web-bot-auth" }

--- a/crates/web-bot-auth/Cargo.toml
+++ b/crates/web-bot-auth/Cargo.toml
@@ -21,3 +21,4 @@ serde_json = { workspace = true }
 sha2 = { workspace = true }
 base64 = { workspace = true }
 data-url = { workspace = true }
+percent-encoding = { workspace = true }

--- a/crates/web-bot-auth/src/lib.rs
+++ b/crates/web-bot-auth/src/lib.rs
@@ -71,6 +71,10 @@ pub enum ImplementationError {
     /// during both signing and verification, as both steps require constructing the signature
     /// base.
     NonAsciiContentFound,
+    /// When normalizing path, query, or authority to percent-decoded forms as mandated by RFC 9421,
+    /// an invalid UTF-8 sequence was found. This will be thrown during signing, and indicates malformed
+    /// UTF-8 input.
+    InvalidUTF8Found,
     /// Signature bases are terminated with a line beginning with `@signature-params`. This error
     /// is thrown if the value of that line could not be converted into a structured field value.
     /// This is considered "impossible" as invalid values should not be present in the structure


### PR DESCRIPTION
For the authority, path, and scheme components, RFC 9421 (by citing Section 4.3.2 of RFC 3968) requires that

> Characters other than those in the "reserved" set are equivalent to
> their percent-encoded octets: the normal form is to not encode them.

This implies that we need to ensure we perform percent decoding to arrive at the normal form, ensuring that percent-encoded URLs and their non-encoded forms are treated as equivalent.

This change adds the necessary requirements and supplies a test for the same.

**Note**

I'm actually not entirely sure if we _must_ do percent-decoding - I'm discussing this privately with @thibmeu . In the event we discover that percent-decoding is not required, we should still enforce hostname and scheme lowercasing as well as treating an empty path string correctly during signing, which this PR introduces for sure.