### PR TITLE
Add /v0/api/verify

### DIFF
--- a/examples/browser-extension/README.md
+++ b/examples/browser-extension/README.md
@@ -68,6 +68,7 @@ You can confirm the policy is installed by navigating to `chrome://policy` and m
 ## Debugging the Extension
 
 Extensions installed by an Enterprise policy do not enable the DevTools by default. To enable the DevTools, open the system's policy file and add the following entry:
+
 ```
 "DeveloperToolsAvailability": 1
 ```

--- a/examples/verification-workers/src/html.ts
+++ b/examples/verification-workers/src/html.ts
@@ -253,8 +253,7 @@ footer {
       "x":"JrQLj5P_89iXES9-vFgrIy29clF9CC_oPPsw3c5D0bs",
       "nbf": 1743465600000
     }
-  ],
-  "purpose": "rag"
+  ]
 }
       </pre>
 

--- a/examples/verification-workers/src/index.ts
+++ b/examples/verification-workers/src/index.ts
@@ -50,34 +50,104 @@ const getSigner = async (): Promise<Signer> => {
 	return Ed25519Signer.fromJWK(jwk);
 };
 
-async function verifyEd25519(
+function verifyEd25519(
+	directory: Directory
+): (
 	data: string,
 	signature: Uint8Array,
 	params: VerificationParams
-) {
-	// note that here we use getDirectory, but this is as simple as a fetch
-	const directory = await getDirectory();
+) => Promise<void> {
+	return async (data, signature, params) => {
+		// note that here we use getDirectory, but this is as simple as a fetch
+		const key = await crypto.subtle.importKey(
+			"jwk",
+			directory.keys[0],
+			{ name: "Ed25519" },
+			true,
+			["verify"]
+		);
 
-	const key = await crypto.subtle.importKey(
-		"jwk",
-		directory.keys[0],
-		{ name: "Ed25519" },
-		true,
-		["verify"]
-	);
+		const encodedData = new TextEncoder().encode(data);
 
-	const encodedData = new TextEncoder().encode(data);
+		const isValid = await crypto.subtle.verify(
+			{ name: "Ed25519" },
+			key,
+			signature,
+			encodedData
+		);
 
-	const isValid = await crypto.subtle.verify(
-		{ name: "Ed25519" },
-		key,
-		signature,
-		encodedData
-	);
+		if (!isValid) {
+			throw new Error("invalid signature");
+		}
+	};
+}
 
-	if (!isValid) {
-		throw new Error("invalid signature");
+const SignatureValidationStatus = {
+	NEUTRAL: "neutral",
+	INVALID: "invalid",
+	VALID: "valid",
+} as const;
+type SignatureValidationStatus =
+	(typeof SignatureValidationStatus)[keyof typeof SignatureValidationStatus];
+
+async function verifySignature(
+	env: Env,
+	request: Request
+): Promise<SignatureValidationStatus> {
+	if (request.headers.get("Signature") === null) {
+		return SignatureValidationStatus.NEUTRAL;
 	}
+
+	const signatureAgent = request.headers.get("Signature-Agent");
+	let directory: Directory;
+	if (signatureAgent && !signatureAgent.includes(env.SIGNATURE_AGENT)) {
+		// make "some" validatation of the Signature-Agent header before making a request
+		let parsed: string;
+		try {
+			parsed = JSON.parse(signatureAgent);
+			const url = new URL(parsed);
+			if (url.protocol !== "https:") {
+				throw new Error(
+					'The demo only supports "https:" scheme for Signature-Agent header'
+				);
+			}
+			if (url.pathname !== "/") {
+				throw new Error(
+					`Only support signature-agent at the root, got "${url.pathname}"`
+				);
+			}
+		} catch (_e) {
+			console.error(
+				`Failed to validate Signature-Agent header: ${signatureAgent}`
+			);
+			return SignatureValidationStatus.INVALID;
+		}
+		if (parsed.endsWith("/")) {
+			parsed = parsed.slice(0, -1);
+		}
+		console.log(
+			`Fetching \`Signature-Agent\` directory from: "${parsed}${HTTP_MESSAGE_SIGNATURES_DIRECTORY}"`
+		);
+		directory = await fetch(
+			`${parsed}${HTTP_MESSAGE_SIGNATURES_DIRECTORY}`
+		).then((r) => r.json());
+	} else {
+		directory = await getDirectory();
+	}
+
+	try {
+		await verify(request, verifyEd25519(directory));
+	} catch (e) {
+		console.error(e);
+		return SignatureValidationStatus.INVALID;
+	}
+
+	console.log("Signature verified successfully");
+	if (signatureAgent) {
+		console.log(`Signature-Agent: "${signatureAgent}"`);
+	}
+
+	return SignatureValidationStatus.VALID;
 }
 
 export default {
@@ -90,6 +160,11 @@ export default {
 					.map(([key, value]) => `${key}: ${value}`)
 					.join("\n")
 			);
+		}
+
+		if (url.pathname.startsWith("/v0/api/verify")) {
+			const status = await verifySignature(env, request);
+			return new Response(status);
 		}
 
 		if (url.pathname.startsWith(HTTP_MESSAGE_SIGNATURES_DIRECTORY)) {
@@ -108,23 +183,22 @@ export default {
 			});
 		}
 
-		if (request.headers.get("Signature") === null) {
-			return new Response(neutralHTML, {
-				headers: { "content-type": "text/html" },
-			});
+		const status = await verifySignature(request);
+		switch (status) {
+			case SignatureValidationStatus.NEUTRAL:
+				return new Response(neutralHTML, {
+					headers: { "content-type": "text/html; charset=utf-8" },
+				});
+			case SignatureValidationStatus.INVALID:
+				return new Response(invalidHTML, {
+					headers: { "content-type": "text/html; charset=utf-8" },
+				});
+			case SignatureValidationStatus.VALID:
+				return new Response(validHTML, {
+					headers: { "content-type": "text/html; charset=utf-8" },
+				});
 		}
-
-		try {
-			await verify(request, verifyEd25519);
-		} catch (e) {
-			console.error(e);
-			return new Response(invalidHTML, {
-				headers: { "content-type": "text/html" },
-			});
-		}
-		return new Response(validHTML, {
-			headers: { "content-type": "text/html" },
-		});
+		return new Response("unhandled case", { status: 500 });
 	},
 	// On a schedule, send a web-bot-auth signed request to a target endpoint
 	async scheduled(ctx, env, ectx) {


### PR DESCRIPTION
It allows to get a shorthand to validate a signature, instead of parsing the HTML page that is targetted at browsers.

Available at https://http-message-signatures-example.research.cloudflare.com/

In addition, this commit adds support to read signature-agent (only https: scheme)

Note: that commit does not add the endpoint in the documentation yet

fyi @sandormajor 