### PR TITLE
Bump Rust version to trigger automated release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -572,7 +572,7 @@ dependencies = [
 
 [[package]]
 name = "http-signature-directory"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "clap",
  "env_logger",
@@ -1183,7 +1183,7 @@ dependencies = [
 
 [[package]]
 name = "rust-examples"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "indexmap",
  "web-bot-auth",
@@ -1774,7 +1774,7 @@ dependencies = [
 
 [[package]]
 name = "web-bot-auth"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "base64",
  "data-url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 authors = [
     "Akshat Mahajan <akshat@cloudflare.com>",
     "Gauri Baraskar <gbaraskar@cloudflare.com>",
@@ -32,4 +32,4 @@ serde_json = "1.0.140"
 data-url = "0.3.1"
 
 # workspace dependencies
-web-bot-auth = { version = "0.5.0", path = "./crates/web-bot-auth" }
+web-bot-auth = { version = "0.5.1", path = "./crates/web-bot-auth" }


### PR DESCRIPTION
Major change since last release:

Add a useragent header when fetching data + print response if not JSON (#59)