### PR TITLE
Release v1.0.0 of web-bot-auth crates

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -49,13 +49,13 @@ jobs:
       - name: Set rust toolchain
         run: rustup override set 1.87 && rustup component add clippy rustfmt && rustup target add wasm32-unknown-unknown
       - run: cargo fetch
-      - run: cargo build --all --verbose --exclude plexi-cli --all-features --tests
-      - run: cargo build --all --verbose --exclude plexi-cli --exclude http-signature-directory --all-features --tests --target wasm32-unknown-unknown
+      - run: cargo build --all --verbose --all-features --tests
+      - run: cargo build --all --verbose --exclude http-signature-directory --all-features --tests --target wasm32-unknown-unknown
       - run: cargo check --tests --examples --benches --all-features
       - run: cargo clippy --all-features --all-targets -- -D warnings
       - run: cargo fmt --all -- --check
-      - run: cargo doc --all --exclude plexi-cli --all-features --document-private-items
-      - run: cargo test --all --verbose --exclude plexi-cli --all-features
+      - run: cargo doc --all --all-features --document-private-items
+      - run: cargo test --all --verbose --all-features
 
   deploy-rust:
     name: Deploy Rust Crates

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -47,7 +47,7 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Set rust toolchain
-        run: rustup override set 1.87 && rustup component add clippy rustfmt && rustup target add wasm32-unknown-unknown
+        run: rustup component add clippy rustfmt && rustup target add wasm32-unknown-unknown
       - run: cargo fetch
       - run: cargo build --all --verbose --all-features --tests
       - run: cargo build --all --verbose --exclude http-signature-directory --all-features --tests --target wasm32-unknown-unknown
@@ -85,8 +85,6 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: Set rust toolchain
-        run: rustup override set 1.87
       - run: cargo publish -p web-bot-auth # will fail if we don't bump the version
         continue-on-error: true
       - run: cargo publish -p http-signature-directory # will fail if we don't bump the version

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,7 +595,7 @@ dependencies = [
 
 [[package]]
 name = "http-signature-directory"
-version = "0.5.1"
+version = "1.0.0"
 dependencies = [
  "clap",
  "env_logger",
@@ -1246,7 +1246,7 @@ dependencies = [
 
 [[package]]
 name = "rust-examples"
-version = "0.5.1"
+version = "1.0.0"
 dependencies = [
  "indexmap",
  "time",
@@ -1463,7 +1463,7 @@ dependencies = [
 
 [[package]]
 name = "signature-agent-card-and-registry"
-version = "0.5.1"
+version = "1.0.0"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -1892,7 +1892,7 @@ dependencies = [
 
 [[package]]
 name = "web-bot-auth"
-version = "0.5.1"
+version = "1.0.0"
 dependencies = [
  "base64",
  "data-url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.5.1"
+version = "1.0.0"
 authors = [
     "Akshat Mahajan <akshat@cloudflare.com>",
     "Gauri Baraskar <gbaraskar@cloudflare.com>",
@@ -35,4 +35,4 @@ regex = "1.12.2"
 time = { version = "0.3.44" }
 
 # workspace dependencies
-web-bot-auth = { version = "0.5.1", path = "./crates/web-bot-auth" }
+web-bot-auth = { version = "1.0.0", path = "./crates/web-bot-auth" }

--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ This deployment allows to test your implementation.
 | [Caddy Plugin](./examples/caddy-plugin/)               | Verify RFC 9421 `Signature` for every incoming request |
 | [Rust](./examples/rust/)                               | Verify a sample test request                           |
 
+### HTTP Signature Directories
+
+| Example                                                            | Description                                                    |
+| :----------------------------------------------------------------- | :------------------------------------------------------------- |
+| [Cloudflare Workers](./examples/signature-agent-card-and-registry) | Host a signature directory on Cloudflare Workers, using the [signature agent card and registry](https://datatracker.ietf.org/doc/draft-meunier-webbotauth-registry/) format |
+
 ## Development
 
 This repository uses [npm](https://docs.npmjs.com/cli/v11/using-npm/workspaces) and [cargo](https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html) workspaces. There are several packages which it provides:

--- a/crates/http-signature-directory/src/main.rs
+++ b/crates/http-signature-directory/src/main.rs
@@ -84,11 +84,11 @@ impl SignedMessage for SignedDirectory<'_> {
                 vec![]
             }
             CoveredComponent::HTTP(HTTPField { name, .. }) => {
-                if let Some(header) = self.headers.get(name) {
-                    if let Ok(value) = header.to_str() {
-                        debug!("Found {} for header {}", value, name);
-                        return vec![String::from(value)];
-                    }
+                if let Some(header) = self.headers.get(name)
+                    && let Ok(value) = header.to_str()
+                {
+                    debug!("Found {} for header {}", value, name);
+                    return vec![String::from(value)];
                 }
 
                 debug!("No value for header {:?} found", name);
@@ -313,8 +313,7 @@ fn main() -> Result<(), String> {
                                     .and_then(|tag| tag.as_string())
                                     .is_some_and(|tag| tag.as_str() == thumbprint)
                                 && innerlist.items.iter().any(|item| {
-                                    (*item)
-                                        .bare_item
+                                    item.bare_item
                                         .as_string()
                                         .is_some_and(|s| (*s).as_str() == "@authority")
                                 })

--- a/crates/http-signature-directory/src/main.rs
+++ b/crates/http-signature-directory/src/main.rs
@@ -61,28 +61,37 @@ struct RawKeyData {
     x: String,
 }
 
-struct SignedDirectory {
-    signature: Vec<String>,
-    input: Vec<String>,
+struct SignedDirectory<'a> {
+    headers: &'a reqwest::header::HeaderMap,
     authority: String,
 }
 
-impl SignedMessage for SignedDirectory {
+impl SignedMessage for SignedDirectory<'_> {
     fn lookup_component(&self, name: &CoveredComponent) -> Vec<String> {
         match name {
             CoveredComponent::Derived(DerivedComponent::Authority { req: true }) => {
-                error!(
-                    "Expected `@authority`;req in signature input components, but did not find it"
+                debug!(
+                    "Resolved {} for derived component {:?}",
+                    self.authority, name
                 );
+
                 vec![self.authority.clone()]
             }
+            CoveredComponent::Derived(DerivedComponent::Authority { req: false }) => {
+                error!(
+                    "You are signing a plain `@authority` without the `req` component parameter. Fix by signing with `req` so that Signature-Input uses `\"@authority\";req` instead",
+                );
+                vec![]
+            }
             CoveredComponent::HTTP(HTTPField { name, .. }) => {
-                if name == "signature" {
-                    return self.signature.clone();
+                if let Some(header) = self.headers.get(name) {
+                    if let Ok(value) = header.to_str() {
+                        debug!("Found {} for header {}", value, name);
+                        return vec![String::from(value)];
+                    }
                 }
-                if name == "signature-input" {
-                    return self.input.clone();
-                }
+
+                debug!("No value for header {:?} found", name);
                 vec![]
             }
             _ => vec![],
@@ -175,9 +184,10 @@ fn main() -> Result<(), String> {
         warnings.push("No Content Type header found".to_string());
     }
 
+    let headers = response.headers().clone();
+
     // Extract signature headers
-    let signature_headers: Vec<String> = response
-        .headers()
+    let signature_headers: Vec<String> = headers
         .get_all("Signature")
         .iter()
         .filter_map(|header| header.to_str().map(String::from).ok())
@@ -188,8 +198,7 @@ fn main() -> Result<(), String> {
         signature_headers
     );
 
-    let signature_inputs: Vec<String> = response
-        .headers()
+    let signature_inputs: Vec<String> = headers
         .get_all("Signature-Input")
         .iter()
         .filter_map(|header| header.to_str().map(String::from).ok())
@@ -284,8 +293,7 @@ fn main() -> Result<(), String> {
                     None => {
                         // Key imported successfully, now verify signature
                         let directory = SignedDirectory {
-                            signature: signature_headers.clone(),
-                            input: signature_inputs.clone(),
+                            headers: &headers,
                             authority: String::from(authority),
                         };
 
@@ -305,7 +313,10 @@ fn main() -> Result<(), String> {
                                     .and_then(|tag| tag.as_string())
                                     .is_some_and(|tag| tag.as_str() == thumbprint)
                                 && innerlist.items.iter().any(|item| {
-                                    *item == sfv::Item::new(sfv::StringRef::constant("@authority"))
+                                    (*item)
+                                        .bare_item
+                                        .as_string()
+                                        .is_some_and(|s| (*s).as_str() == "@authority")
                                 })
                         }) {
                             Ok(verifier) => {

--- a/examples/signature-agent-card-and-registry/Cargo.toml
+++ b/examples/signature-agent-card-and-registry/Cargo.toml
@@ -19,9 +19,6 @@ worker = { version = "0.7", features = ['http'] }
 worker-macros = { version = "0.7", features = ['http'] }
 web-bot-auth = { workspace = true }
 
-# The following libraries are deliberately held back to these versions.
-# `ed25519-dalek` doesn't support latest `rand` in its latest stable version,
-# so we pin to the version of `rand` and `rand_chaca` the latest versions do support. 
 ed25519-dalek = { version = "2.2.0", features = ['rand_core'] }
 rand = { version = "0.8", default-features = false, features = ["getrandom"] }
 getrandom = { version = "0.2", features = ["js"] }


### PR DESCRIPTION
# Release v1.0.0 of web-bot-auth crates
    
These include some pretty significant and breaking changes:

1. Dependency on `time` library is now required instead of `std::time`
   for all API users. As a bonus, however, we gain support on Cloudflare
   Workers as well as removal of a class of errors related to system
   clocks and `created` / `expires` parsing.

2. A number of constructs were removed: `WebBotAuthSignedMessage`,
   `SignedMessage::fetch_all_signature_headers` and
   `SignedMessage::fetch_all_signature_inputs`. The library now exposes
   a single method to look up components to verify.

3. `Signature-Agent` can now be parsed as a dictionary, but retains
   support for being parsed as a raw string.

4. It enforces use of `req` parameter for `@authority` in `http-message-dir`. This is in
   line with the specification, but can break verification of existing
   sites.

These changes are sufficiently breaking enough to justify using semver
bump.

# Make `@authority;req` errors more prominent + fix example signature generation
    
This change amends the `http-signature-dir` to print an error log
whendirectories mistakenly sign `@authority` without the `req`
parameter.

It fixes a bug with the example signature agent card generation where
only the host component was used to sign `@authority`, rather than the
full host and port pair (i.e. the _actual_ authority component). This
led to verifiers being unable to verify generated signatures.

It fixes some minor comments and superfluous Github Actions changes,
and does some basic refactoring to make the logic a bit more
straightforward in the example. Importantly, it also adds the
`alg` parameter in generated signatures - this is in line with the
opinionated signing we do, whereby other elements normal to web bot auth
are also enforced for arbitrary HTTP signatures.

I also removed the pin on Rust v1.87  in Github Actions, this way we always test against 
the latest Rust version.