### PR TITLE
refactor: replace time::Duration with std::time::Duration in public API

### DIFF
--- a/crates/web-bot-auth/src/lib.rs
+++ b/crates/web-bot-auth/src/lib.rs
@@ -310,6 +310,8 @@ impl WebBotAuthVerifier {
 #[cfg(test)]
 mod tests {
 
+    use std::time::Duration;
+
     use components::DerivedComponent;
     use indexmap::IndexMap;
 
@@ -363,8 +365,9 @@ mod tests {
         assert!(advisory.is_expired.unwrap_or(true));
         assert!(!advisory.nonce_is_invalid.unwrap_or(true));
         let timing = verifier.verify(&keyring, None).unwrap();
-        assert!(timing.generation.whole_nanoseconds() > 0);
-        assert!(timing.verification.whole_nanoseconds() > 0);
+
+        assert!(timing.generation.as_nanos() > 0);
+        assert!(timing.verification.as_nanos() > 0);
     }
 
     #[test]
@@ -446,7 +449,7 @@ mod tests {
         signer
             .generate_signature_headers_content(
                 &mut mytest,
-                time::Duration::seconds(10),
+                Duration::from_secs(10),
                 Algorithm::Ed25519,
                 &private_key,
             )
@@ -463,8 +466,8 @@ mod tests {
         assert!(!advisory.nonce_is_invalid.unwrap_or(true));
 
         let timing = verifier.verify(&keyring, None).unwrap();
-        assert!(timing.generation.whole_nanoseconds() > 0);
-        assert!(timing.verification.whole_nanoseconds() > 0);
+        assert!(timing.generation.as_nanos() > 0);
+        assert!(timing.verification.as_nanos() > 0);
     }
 
     #[test]

--- a/crates/web-bot-auth/src/message_signatures.rs
+++ b/crates/web-bot-auth/src/message_signatures.rs
@@ -6,7 +6,8 @@ use regex::bytes::Regex;
 use sfv::SerializeValue;
 use std::fmt::Write as _;
 use std::sync::LazyLock;
-use time::{Duration, UtcDateTime};
+use std::time::Duration;
+use time::UtcDateTime;
 static OBSOLETE_LINE_FOLDING: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"\s*\r\n\s+").unwrap());
 
@@ -575,7 +576,8 @@ impl MessageVerifier {
         .ok_or(ImplementationError::NoSuchKey)?;
         let generation = UtcDateTime::now();
         let (base_representation, _) = self.parsed.base.into_ascii()?;
-        let generation = UtcDateTime::now() - generation;
+        let generation = (UtcDateTime::now() - generation).unsigned_abs();
+
         match &keying_material.0 {
             Algorithm::Ed25519 => {
                 use ed25519_dalek::{Signature, Verifier, VerifyingKey};
@@ -591,7 +593,7 @@ impl MessageVerifier {
                     .map_err(ImplementationError::FailedToVerify)
                     .map(|()| SignatureTiming {
                         generation,
-                        verification: UtcDateTime::now() - verification,
+                        verification: (UtcDateTime::now() - verification).unsigned_abs(),
                     })
             }
             other => Err(ImplementationError::UnsupportedAlgorithm(other.clone())),
@@ -659,8 +661,8 @@ mod tests {
         );
         let verifier = MessageVerifier::parse(&test, |(_, _)| true).unwrap();
         let timing = verifier.verify(&keyring, None).unwrap();
-        assert!(timing.generation.whole_nanoseconds() > 0);
-        assert!(timing.verification.whole_nanoseconds() > 0);
+        assert!(timing.generation.as_nanos() > 0);
+        assert!(timing.verification.as_nanos() > 0);
     }
 
     #[test]
@@ -713,7 +715,7 @@ mod tests {
             signer
                 .generate_signature_headers_content(
                     &mut test,
-                    Duration::seconds(10),
+                    Duration::from_secs(10),
                     Algorithm::Ed25519,
                     &private_key
                 )

--- a/examples/rust/signing.rs
+++ b/examples/rust/signing.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use indexmap::IndexMap;
-use time::Duration;
+use std::time::Duration;
 use web_bot_auth::{
     components::{
         CoveredComponent, DerivedComponent, HTTPField, HTTPFieldParameters, HTTPFieldParametersSet,
@@ -71,7 +71,7 @@ fn main() {
     signer
         .generate_signature_headers_content(
             &mut headers,
-            Duration::seconds(10),
+            Duration::from_secs(10),
             Algorithm::Ed25519,
             &private_key,
         )

--- a/examples/signature-agent-card-and-registry/src/lib.rs
+++ b/examples/signature-agent-card-and-registry/src/lib.rs
@@ -4,7 +4,7 @@ use indexmap::map::IndexMap;
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use time::Duration;
+use std::time::Duration;
 use web_bot_auth::{
     components::{CoveredComponent, DerivedComponent, HTTPField, HTTPFieldParametersSet},
     keyring::{Algorithm, Thumbprintable},
@@ -167,7 +167,7 @@ async fn fetch(req: HttpRequest, env: Env, _ctx: Context) -> Result<Response> {
             signer
                 .generate_signature_headers_content(
                     &mut generator,
-                    Duration::seconds(10),
+                    Duration::from_secs(10),
                     Algorithm::Ed25519,
                     signing_key.as_bytes(),
                 )


### PR DESCRIPTION
Closes https://github.com/cloudflare/web-bot-auth/issues/74

This updates the public API surfaced via `web_bot_auth::message_signatures::MessageSigner::generate_signature_headers_content` and `web_bot_auth::message_signatures::SignatureTiming` to use `std::time::Duration` instead. The `time` crate is now an implementation detail.
This change makes usage with other time crates easier. You do not need to pull in the `time` crate or convert from a different `Duration` into `time::Duration` (direct or via `std::time::Duration`)

I tested this with https://github.com/cloudflare/web-bot-auth/tree/main/examples/signature-agent-card-and-registry and did not find any errors. I am looking forward to better test instructions.


This is a breaking change and requires a minor version bump.