### PR TITLE
Release v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,7 +595,7 @@ dependencies = [
 
 [[package]]
 name = "http-signature-directory"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "clap",
  "env_logger",
@@ -1246,7 +1246,7 @@ dependencies = [
 
 [[package]]
 name = "rust-examples"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "indexmap",
  "time",
@@ -1463,7 +1463,7 @@ dependencies = [
 
 [[package]]
 name = "signature-agent-card-and-registry"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -1892,7 +1892,7 @@ dependencies = [
 
 [[package]]
 name = "web-bot-auth"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "base64",
  "data-url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.1"
+version = "0.7.0"
 authors = [
     "Akshat Mahajan <akshat@cloudflare.com>",
     "Gauri Baraskar <gbaraskar@cloudflare.com>",
@@ -35,4 +35,4 @@ regex = "1.12.2"
 time = { version = "0.3.44" }
 
 # workspace dependencies
-web-bot-auth = { version = "0.6.1", path = "./crates/web-bot-auth" }
+web-bot-auth = { version = "0.7.0", path = "./crates/web-bot-auth" }


### PR DESCRIPTION
- [Implement `std:error:Error` trait for `ImplementationError`](https://github.com/cloudflare/web-bot-auth/pull/78)

- [refactor: replace time::Duration with std::time::Duration in public API](https://github.com/cloudflare/web-bot-auth/pull/79).

The last makes a breaking change to our APIs, and so mandates a minor version bump per our existing convention.