### PR TITLE
Validate directory uri

### DIFF
--- a/examples/verification-workers/src/debug-html.ts
+++ b/examples/verification-workers/src/debug-html.ts
@@ -12,155 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { theme } from "./index-html";
+
 function escapeAttribute(value: string): string {
 	return value.replaceAll("&", "&amp;").replaceAll('"', "&quot;");
 }
 
-const theme = `<style>* {
-  margin: 0;
-  padding: 0;
-  border: none;
-}
-
-html { font-size: 62.5%; }
-
-body {
-  margin: 0;
-  font-family: open sans, HelveticaNeue, Helvetica Neue, Helvetica, Arial, sans-serif;
-  font-size: 1.5em;
-  font-weight: 400;
-  line-height: 1.6;
-  color: #222;
-}
-
-h1 {
-  font-family: Montserrat, helvetica, arial, sans-serif;
-  font-size: 6rem;
-  font-weight: 700;
-  line-height: 6.5rem;
-  text-align: center;
-  color: black;
-}
-h3 {
-  font-size: 2rem;
-  font-weight: 600;
-  line-height: 2.4rem;
-  padding-top: 3rem;
-  padding-bottom: .5rem;
-}
-h4 {
-  font-size: 1.6rem;
-  font-weight: 600;
-  line-height: 2.6rem;
-  padding: 1.4rem 0 1rem;
-}
-p {
-  font-size: 1.6rem;
-  padding-bottom: 1.3rem;
-}
-a { color: #125CCA; }
-a:hover { color: #3BA3BB; }
-
-header {
-  position: relative;
-  width: 100%;
-  padding: 40px 0 65px;
-  background-color: #DDE8EF;
-}
-
-header.success {
-  background-color: #B3E1EF;
-}
-
-header.failure {
-  background-color: #d44613;
-}
-
-header h3 {
-  text-align: center;
-}
-
-.toc li {
-  display: inline-block;
-  position: relative;
-  width: 49%;
-  box-sizing: border-box;
-  background-color: #DDE8EF;
-  list-style-type: none;
-  text-align: center;
-}
-.toc li:not(:first-of-type) {
-  margin-left: 2%;
-}
-.toc li:hover { background-color: #B3E1EF; }
-.toc a {
-  display: inline-block;
-  width: 100%;
-  padding: 2px 0 3px;
-  font-weight: 600;
-  text-decoration: none;
-  color: #464646;
-}
-
-section {
-  position: relative;
-  margin: 20px 0;
-  padding: 0 20px;
-}
-section > * {
-  max-width: 640px;
-  margin: 0 auto;
-}
-
-.illustrated {  }
-img {
-  display: block;
-  margin: 0 auto;
-  padding: 2rem 0;
-}
-.illustration {
-  max-height: 350px;
-  max-width: 100%;
-}
-
-#intro {
-  padding-top: 65px;
-}
-#intro p {
-  font-weight: 400;
-  font-size: 1.8rem;
-  line-height: 3rem;
-  padding-top: 2rem;
-}
-
-/*table style from bootstrap*/
-table {
-  width: 100%;
-  margin-bottom: 20px;
-  padding: 1rem 0;
-}
-table th,
-table td {
-  padding: 8px;
-  line-height: 1.42857143;
-  vertical-align: top;
-  border-bottom: 1px solid #ddd;
-}
-table > thead > tr > th {
-  vertical-align: bottom;
-  border-bottom: 2px solid #ddd;
-}
-.table-condensed th,
-.table-condensed td {
-  padding: 5px;
-}
-
-.form-inline,
+const debugStyle = `<style>
 form {
   padding: 1.5rem 3rem 3rem;
   background-color: #DDE8EF;
 }
-label { display: block; }
 input, select, textarea, button {
   -webkit-appearance: none;
   -moz-appearance: none;
@@ -170,10 +32,6 @@ input, select, textarea, button {
   font-weight: 400;
   margin-top: 1rem;
 }
-input {
-  padding: 6px 12px;
-  width: 45%;
-}
 select {
   background-color: white;
   border: 1px solid #999;
@@ -182,21 +40,11 @@ select {
   width: 100%;
 }
 button {
-  color: white;
   background-color: #2F6F8F;
-  padding: 6px 12px;
+  border-radius: 0;
 }
 button:hover { background-color: #255A74; }
-button:hover,
-button:focus {
-  outline: none;
-  box-shadow: 0 0 0 3px #3BA3BD;
-}
-button:active {
-  box-shadow: inset 0 1px 1px 1px rgba(0,0,0,.4);
-}
 input[type="url"],
-input[type="text"],
 textarea {
   border: 1px solid #999;
   box-sizing: border-box;
@@ -241,22 +89,6 @@ textarea {
 .validation-result li {
   margin-bottom: 0.25rem;
 }
-
-.question-list {
-  margin-bottom: 2rem;
-}
-.question-list li {
-  margin-left: 1.8rem;
-}
-
-footer {
-  border-top: 1px solid #ccc;
-  padding: 1rem 3rem;
-}
-.text-muted {
-  font-size: 13px;
-  color: #888;
-}
 @media (max-width: 640px) {
   .header-grid {
     grid-template-columns: 1fr;
@@ -268,99 +100,6 @@ footer {
 }
 </style>`;
 
-export const generateHTML = (status: boolean | undefined) => `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>Identify Bots with HTTP Message Signatures</title>
-  ${theme}
-</head>
-<body>
-  <header id="top" ${status !== undefined ? `class="${status ? "success" : "failure"}"` : ""}>
-    <h1>Identify Bots with HTTP Message Signatures</h1>
-    <h3>
-    ${status === undefined ? "Your browser does not support HTTP Message Signatures" : ""}
-    ${status === false ? "The Signature you sent does not validate against test public key" : ""}
-    ${status === true ? "You successfully authenticated as owning the test public key" : ""}
-    </h3>
-  </header>
-  <section>
-    <p>
-      HTTP Message Signatures are a mechanism to create, encode, and verify signatures over components of an HTTP message.
-      They are standardised by the IETF in <a href="https://datatracker.ietf.org/doc/html/rfc9421">RFC 9421</a>.
-
-      This website validates the presence of such signature as defined in <a href="https://github.com/thibmeu/http-message-signatures-directory">draft-meunier-web-bot-auth-architecture</a>.
-    </p>
-    <p>
-      This website checks for an Ed25519 signature on incoming request. They should be signed by a test public key defined in <a href="https://datatracker.ietf.org/doc/html/rfc9421#name-example-ed25519-test-key">Appendix B.1.4 of RFC 9421</a>.
-    </p>
-
-    <h2>Why do platforms and websites need this?</h2>
-    <p>
-      As a platform provider, I would like to ensure websites are able to identify requests originating from my service.
-      At the moment, I share IP ranges, but this is long to deploy, cumbersome to maintain, and costly, especially with the multiplication of services, and the need to localise outgoing traffic with a forward proxy.
-      It's even more pressing as I onboard multiple companies on my platform that need to have their own identity.
-      And user agent headers do not have any integrity protection.
-    </p>
-    <p>
-      It's time for websites to know who's calling, and for platforms to prove it.
-    </p>
-
-    <h2>How to retrieve the public key used by this website</h2>
-    <p>
-      We define a key directory accessible under <a>/.well-known/http-message-signatures-directory</a>
-
-      The directory looks as follow
-      </p>
-      <pre>{
-  "keys": [
-    {
-      "kid":"poqkLGiymh_W0uP6PZFw-dvez3QJT5SolqXBCW38r0U",
-      "kty":"OKP",
-      "crv":"Ed25519",
-      "x":"JrQLj5P_89iXES9-vFgrIy29clF9CC_oPPsw3c5D0bs",
-      "nbf": 1743465600000
-    }
-  ]
-}
-      </pre>
-
-      <p>
-      Parameters are defined as follow:
-
-      <ul>
-        <li><strong>keys</strong>: an array of serialised JSON Web Key defined by <a href="https://www.rfc-editor.org/rfc/rfc7517.html">RFC 7517</a>
-          <ul style="padding-left:1em">
-          <li><strong>kid</strong>: JWK Thumbprint as defined in <a href="https://www.rfc-editor.org/rfc/rfc7638.html">RFC 7638</a></li>
-          <li><strong>nbf</strong>: start of the validity of the public key as a unix timestamp in milliseconds defined by <a href="https://www.rfc-editor.org/rfc/rfc7519.html">RFC 7519</a></li>
-          <li><strong>exp</strong>: end of the validity of the public key as a unix timestamp in milliseconds defined by <a href="https://www.rfc-editor.org/rfc/rfc7519.html">RFC 7519</a></li>
-          <li><strong>...jwk</strong>: JWK public cryptographic material</li>
-          </ul>
-        </li>
-        <li><strong>purpose</strong>: represents what a signature means. Examples could be the draft for <a href="https://github.com/martinthomson/sup-ai">Short usage preference proposed</a>.</li>
-      </ul>
-    </p>
-
-    <h2>It's hard to debug. How can this website help?</h2>
-    <p>
-      Use the <a href="/debug">debug page</a> to validate key directories and signature headers.
-    </p>
-
-    <h2>I have comments and want to contribute. Where do I go?</h2>
-    <p>
-    First off, this is fantastic news!
-    </p>
-    <p>
-    To contribute to this website, you can go to <a href="https://github.com/cloudflareresearch/web-bot-auth">cloudflareresearch/web-bot-auth</a>.
-    </p>
-    <p>
-    To contribute to the standard discussion, the current draft is hosted on <a href="https://github.com/thibmeu/http-message-signatures-directory">thibmeu/http-message-signatures-directory</a>, and is being discussed on <a href="https://mailarchive.ietf.org/arch/browse/web-bot-auth/">web-bot-auth</a> IETF mailing list.
-    </p>
-  </section>
-</body>
-</html>`;
-
 export const generateDebugHTML = (turnstileSiteKey: string) => `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -369,6 +108,7 @@ export const generateDebugHTML = (turnstileSiteKey: string) => `<!DOCTYPE html>
   <title>Debug HTTP Message Signatures</title>
   <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
   ${theme}
+  ${debugStyle}
 </head>
 <body>
   <header id="top">
@@ -377,7 +117,7 @@ export const generateDebugHTML = (turnstileSiteKey: string) => `<!DOCTYPE html>
   </header>
   <section>
     <p>
-      This page collects debugging tools for Web Bot Auth implementations. Start by validating the key directory. Header verification is reserved for a later step.
+      This page collects debugging tools for Web Bot Auth implementations. Start by validating the key directory.
     </p>
 
     <div class="debug-tool">
@@ -551,8 +291,6 @@ export const generateDebugHTML = (turnstileSiteKey: string) => `<!DOCTYPE html>
       return { key: match[1], components, params, input: header.replace(/^[^=]+=/, "") };
     };
 
-    const requestTarget = (url) => url.pathname + url.search;
-
     const componentValue = (component, request, headers) => {
       switch (component) {
         case "@method":
@@ -567,7 +305,7 @@ export const generateDebugHTML = (turnstileSiteKey: string) => `<!DOCTYPE html>
         case "@scheme":
           return request.url.protocol.slice(0, -1);
         case "@request-target":
-          return requestTarget(request.url);
+          return request.url.pathname + request.url.search;
         case "@path":
           return request.url.pathname;
         case "@query":

--- a/examples/verification-workers/src/debug-html.ts
+++ b/examples/verification-workers/src/debug-html.ts
@@ -18,6 +18,18 @@ function escapeAttribute(value: string): string {
 	return value.replaceAll("&", "&amp;").replaceAll('"', "&quot;");
 }
 
+function turnstileScript(siteKey: string): string {
+	return siteKey.length > 0
+		? '<script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>'
+		: "";
+}
+
+function turnstileWidget(siteKey: string): string {
+	return siteKey.length > 0
+		? `<div class="cf-turnstile" data-sitekey="${escapeAttribute(siteKey)}"></div>`
+		: '<p class="text-muted">Turnstile is not configured for this deployment.</p>';
+}
+
 const debugStyle = `<style>
 form {
   padding: 1.5rem 3rem 3rem;
@@ -89,6 +101,14 @@ textarea {
 .validation-result li {
   margin-bottom: 0.25rem;
 }
+.validation-result pre {
+  border: 1px solid #999;
+  box-sizing: border-box;
+  margin-top: 0.75rem;
+  overflow-x: auto;
+  padding: 1rem;
+  white-space: pre-wrap;
+}
 @media (max-width: 640px) {
   .header-grid {
     grid-template-columns: 1fr;
@@ -106,7 +126,7 @@ export const generateDebugHTML = (turnstileSiteKey: string) => `<!DOCTYPE html>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Debug HTTP Message Signatures</title>
-  <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
+  ${turnstileScript(turnstileSiteKey)}
   ${theme}
   ${debugStyle}
 </head>
@@ -128,7 +148,7 @@ export const generateDebugHTML = (turnstileSiteKey: string) => `<!DOCTYPE html>
       <form id="directory-validator">
         <label for="directory-url">Directory URL</label>
         <input id="directory-url" name="url" type="url" placeholder="https://example.com/.well-known/http-message-signatures-directory" required />
-        <div class="cf-turnstile" data-sitekey="${escapeAttribute(turnstileSiteKey)}"></div>
+        ${turnstileWidget(turnstileSiteKey)}
         <button type="submit">Validate directory</button>
         <div id="directory-validation-result" class="validation-result" aria-live="polite"></div>
       </form>
@@ -168,7 +188,7 @@ export const generateDebugHTML = (turnstileSiteKey: string) => `<!DOCTYPE html>
           <textarea id="signature-input-header" name="signature-input" placeholder='sig1=("@method" "@target-uri");created=...' required></textarea>
         </div>
 
-        <div class="cf-turnstile" data-sitekey="${escapeAttribute(turnstileSiteKey)}"></div>
+        ${turnstileWidget(turnstileSiteKey)}
 
         <button type="submit">Verify headers</button>
         <div id="signature-header-validation-result" class="validation-result" aria-live="polite"></div>
@@ -180,6 +200,7 @@ export const generateDebugHTML = (turnstileSiteKey: string) => `<!DOCTYPE html>
     const result = document.getElementById("directory-validation-result");
     const signatureForm = document.getElementById("signature-header-validator");
     const signatureResult = document.getElementById("signature-header-validation-result");
+    const signatureDirectoryURL = document.getElementById("signature-directory-url");
 
     const appendMessages = (heading, messages) => {
       if (messages.length === 0) {
@@ -244,6 +265,14 @@ export const generateDebugHTML = (turnstileSiteKey: string) => `<!DOCTYPE html>
       }
 
       return { errors, warnings: [] };
+    };
+
+    const appendDirectory = (directory) => {
+      const heading = document.createElement("p");
+      heading.textContent = "Fetched directory";
+      const output = document.createElement("pre");
+      output.textContent = JSON.stringify(directory, null, 2);
+      result.append(heading, output);
     };
 
     const base64ToBytes = (value) => {
@@ -318,7 +347,7 @@ export const generateDebugHTML = (turnstileSiteKey: string) => `<!DOCTYPE html>
     const buildSignedData = (parsed, request, headers) => {
       const parts = parsed.components.map((component) => '"' + component + '": ' + componentValue(component, request, headers));
       parts.push('"@signature-params": ' + parsed.input);
-      return parts.join("\n");
+      return parts.join("\\n");
     };
 
     const validateWebBotAuthParams = (params) => {
@@ -403,12 +432,17 @@ export const generateDebugHTML = (turnstileSiteKey: string) => `<!DOCTYPE html>
     form.addEventListener("submit", async (event) => {
       event.preventDefault();
       const data = new FormData(form);
+      const directoryURL = data.get("url");
       result.textContent = "Checking directory...";
+      if (typeof directoryURL === "string") {
+        signatureDirectoryURL.value = directoryURL;
+      }
 
       try {
         const response = await fetch("/v0/api/proxy-directory", { method: "POST", body: data });
         const errors = [];
         const warnings = [];
+        let directory;
 
         if (!response.ok) {
           const body = await response.json();
@@ -420,7 +454,7 @@ export const generateDebugHTML = (turnstileSiteKey: string) => `<!DOCTYPE html>
             warnings.push("Directory returned unexpected Content-Type " + (contentType || "none"));
           }
 
-          const directory = await response.json();
+          directory = await response.json();
           const shapeValidation = validateDirectory(directory);
           errors.push(...shapeValidation.errors);
           warnings.push(...shapeValidation.warnings);
@@ -441,6 +475,9 @@ export const generateDebugHTML = (turnstileSiteKey: string) => `<!DOCTYPE html>
           appendMessages("Directory check failed", errors);
         }
         appendMessages("Warnings", warnings);
+        if (typeof directory !== "undefined") {
+          appendDirectory(directory);
+        }
       } catch {
         result.textContent = "Directory check failed.";
       } finally {

--- a/examples/verification-workers/src/debug-html.ts
+++ b/examples/verification-workers/src/debug-html.ts
@@ -76,6 +76,19 @@ textarea {
 .debug-tool {
   margin-bottom: 3rem;
 }
+.section-heading {
+  align-items: baseline;
+  display: flex;
+  gap: 0.6rem;
+}
+.section-link {
+  opacity: 0;
+  text-decoration: none;
+}
+.debug-tool:hover .section-link,
+.section-link:focus {
+  opacity: 1;
+}
 .header-grid {
   display: grid;
   grid-template-columns: 16rem minmax(0, 1fr);
@@ -145,8 +158,8 @@ export const generateDebugHTML = (turnstileSiteKey: string) => `<!DOCTYPE html>
       This page collects debugging tools for Web Bot Auth implementations. Start by validating the key directory.
     </p>
 
-    <div class="debug-tool">
-      <h2>Validate key directory</h2>
+    <div id="validate-directory" class="debug-tool">
+      <h2 class="section-heading">Validate key directory <a class="section-link" href="#section=validate-directory" data-section="validate-directory">#</a></h2>
       <p>
         Paste the full HTTPS URL for a <code>/.well-known/http-message-signatures-directory</code> endpoint to check whether it returns a usable directory.
       </p>
@@ -160,8 +173,8 @@ export const generateDebugHTML = (turnstileSiteKey: string) => `<!DOCTYPE html>
       </form>
     </div>
 
-    <div class="debug-tool">
-      <h2>Get JWK keyid</h2>
+    <div id="get-jwk-keyid" class="debug-tool">
+      <h2 class="section-heading">Get JWK keyid <a class="section-link" href="#section=get-jwk-keyid" data-section="get-jwk-keyid">#</a></h2>
       <p>
         Paste a JWK to compute its RFC 7638 SHA-256 thumbprint for use as <code>keyid</code>.
       </p>
@@ -173,8 +186,8 @@ export const generateDebugHTML = (turnstileSiteKey: string) => `<!DOCTYPE html>
       </form>
     </div>
 
-    <div class="debug-tool">
-      <h2>Verify request headers</h2>
+    <div id="verify-request-headers" class="debug-tool">
+      <h2 class="section-heading">Verify request headers <a class="section-link" href="#section=verify-request-headers" data-section="verify-request-headers">#</a></h2>
       <p>
         Paste the signed request target, verification JWK, and HTTP Message Signature headers here.
       </p>
@@ -228,6 +241,7 @@ export const generateDebugHTML = (turnstileSiteKey: string) => `<!DOCTYPE html>
     </div>
   </section>
   <script>
+    const sectionLinks = Array.from(document.querySelectorAll(".section-link"));
     const form = document.getElementById("directory-validator");
     const result = document.getElementById("directory-validation-result");
     const keyIDForm = document.getElementById("key-id-calculator");
@@ -236,6 +250,89 @@ export const generateDebugHTML = (turnstileSiteKey: string) => `<!DOCTYPE html>
     const signatureForm = document.getElementById("signature-header-validator");
     const signatureResult = document.getElementById("signature-header-validation-result");
     const signatureJWK = document.getElementById("signature-jwk");
+
+    const fragmentParams = () => new URLSearchParams(window.location.hash.startsWith("#") ? window.location.hash.slice(1) : window.location.hash);
+
+    const formValue = (id) => {
+      const element = document.getElementById(id);
+      return element !== null ? element.value : "";
+    };
+
+    const prefill = (id, name) => {
+      const value = fragmentParams().get(name);
+      const element = document.getElementById(id);
+      if (value !== null && element !== null) {
+        element.value = value;
+      }
+    };
+
+    prefill("directory-url", "directory-url");
+    prefill("key-id-jwk", "key-id-jwk");
+    prefill("signature-jwk", "signature-jwk");
+    if (formValue("key-id-jwk") === "") {
+      prefill("key-id-jwk", "jwk");
+    }
+    if (formValue("signature-jwk") === "") {
+      prefill("signature-jwk", "jwk");
+    }
+    prefill("signature-method", "method");
+    prefill("signature-url", "url");
+    prefill("signature-header", "signature");
+    prefill("signature-agent-header", "signature-agent");
+    prefill("signature-input-header", "signature-input");
+
+    const currentSectionURL = (section) => {
+      const params = new URLSearchParams();
+      const directoryURL = formValue("directory-url");
+      const values = [
+        ["section", section],
+        ["directory-url", directoryURL],
+        ["key-id-jwk", formValue("key-id-jwk")],
+        ["signature-jwk", formValue("signature-jwk")],
+        ["method", formValue("signature-method")],
+        ["url", formValue("signature-url")],
+        ["signature", formValue("signature-header")],
+        ["signature-agent", formValue("signature-agent-header")],
+        ["signature-input", formValue("signature-input-header")],
+      ];
+      for (const [name, value] of values) {
+        if (value !== "") {
+          params.set(name, value);
+        }
+      }
+      const url = new URL(window.location.href);
+      url.search = "";
+      url.hash = params.toString();
+      return url.toString();
+    };
+
+    const scrollToFragmentSection = () => {
+      const section = fragmentParams().get("section");
+      if (section !== null) {
+        const element = document.getElementById(section);
+        if (element !== null) {
+          element.scrollIntoView();
+        }
+      }
+    };
+
+    const updateSectionLink = (link) => {
+      const section = link.getAttribute("data-section") || "";
+      link.href = currentSectionURL(section);
+    };
+
+    for (const link of sectionLinks) {
+      link.addEventListener("pointerenter", () => updateSectionLink(link));
+      link.addEventListener("focus", () => updateSectionLink(link));
+      link.addEventListener("click", (event) => {
+        event.preventDefault();
+        updateSectionLink(link);
+        history.pushState(null, "", link.href);
+        scrollToFragmentSection();
+      });
+    }
+
+    scrollToFragmentSection();
 
     const appendMessagesTo = (target, heading, messages) => {
       if (messages.length === 0) {
@@ -476,6 +573,7 @@ export const generateDebugHTML = (turnstileSiteKey: string) => `<!DOCTYPE html>
     };
 
     const validateWebBotAuthParams = (params) => {
+      const warnings = [];
       if (params.tag !== "web-bot-auth") {
         throw new Error("tag must be 'web-bot-auth'");
       }
@@ -487,8 +585,9 @@ export const generateDebugHTML = (turnstileSiteKey: string) => `<!DOCTYPE html>
         throw new Error("created in the future");
       }
       if (typeof params.expires === "number" && params.expires < now) {
-        throw new Error("signature has expired");
+        warnings.push("signature has expired");
       }
+      return warnings;
     };
 
     const verifySignatureLocally = async (data) => {
@@ -501,7 +600,7 @@ export const generateDebugHTML = (turnstileSiteKey: string) => `<!DOCTYPE html>
       const keyID = await computeJWKKeyID(key);
 
       const parsed = parseSignatureInputHeader(data.get("signature-input"));
-      validateWebBotAuthParams(parsed.params);
+      const warnings = validateWebBotAuthParams(parsed.params);
       if (parsed.params.keyid !== keyID) {
         throw new Error("JWK keyid does not match Signature-Input keyid");
       }
@@ -516,7 +615,8 @@ export const generateDebugHTML = (turnstileSiteKey: string) => `<!DOCTYPE html>
       const signedData = buildSignedData(parsed, request, headers);
       const signature = parseSignatureHeader(parsed.key, data.get("signature"));
       const cryptoKey = await crypto.subtle.importKey("jwk", key, { name: "Ed25519" }, true, ["verify"]);
-      return crypto.subtle.verify({ name: "Ed25519" }, cryptoKey, signature, new TextEncoder().encode(signedData));
+      const valid = await crypto.subtle.verify({ name: "Ed25519" }, cryptoKey, signature, new TextEncoder().encode(signedData));
+      return { valid, warnings };
     };
 
     keyIDForm.addEventListener("submit", async (event) => {
@@ -539,10 +639,16 @@ export const generateDebugHTML = (turnstileSiteKey: string) => `<!DOCTYPE html>
       signatureResult.textContent = "Verifying signature...";
 
       try {
-        if (await verifySignatureLocally(data)) {
-          signatureResult.textContent = "Signature is valid.";
+        const verification = await verifySignatureLocally(data);
+        signatureResult.replaceChildren();
+        const message = document.createElement("p");
+        if (verification.valid) {
+          message.textContent = "Signature is valid.";
+          signatureResult.append(message);
+          appendMessagesTo(signatureResult, "Warnings", verification.warnings);
         } else {
-          signatureResult.textContent = "Signature check failed: invalid signature";
+          message.textContent = "Signature check failed: invalid signature";
+          signatureResult.append(message);
         }
       } catch (error) {
         signatureResult.textContent = "Signature check failed: " + (error instanceof Error ? error.message : String(error));

--- a/examples/verification-workers/src/debug-html.ts
+++ b/examples/verification-workers/src/debug-html.ts
@@ -14,6 +14,8 @@
 
 import { theme } from "./index-html";
 
+const directoryPath = "/.well-known/http-message-signatures-directory";
+
 function escapeAttribute(value: string): string {
 	return value.replaceAll("&", "&amp;").replaceAll('"', "&quot;");
 }
@@ -79,6 +81,9 @@ textarea {
   grid-template-columns: 16rem minmax(0, 1fr);
   gap: 1rem 1.5rem;
   align-items: start;
+}
+.header-grid .field {
+  min-width: 0;
 }
 .header-grid label {
   font-weight: 600;
@@ -148,6 +153,7 @@ export const generateDebugHTML = (turnstileSiteKey: string) => `<!DOCTYPE html>
       <form id="directory-validator">
         <label for="directory-url">Directory URL</label>
         <input id="directory-url" name="url" type="url" placeholder="https://example.com/.well-known/http-message-signatures-directory" required />
+        <p class="text-muted">URL path must end with <code>${directoryPath}</code>.</p>
         ${turnstileWidget(turnstileSiteKey)}
         <button type="submit">Validate directory</button>
         <div id="directory-validation-result" class="validation-result" aria-live="polite"></div>
@@ -155,37 +161,63 @@ export const generateDebugHTML = (turnstileSiteKey: string) => `<!DOCTYPE html>
     </div>
 
     <div class="debug-tool">
+      <h2>Get JWK keyid</h2>
+      <p>
+        Paste a JWK to compute its RFC 7638 SHA-256 thumbprint for use as <code>keyid</code>.
+      </p>
+      <form id="key-id-calculator">
+        <label for="key-id-jwk">JWK</label>
+        <textarea id="key-id-jwk" name="jwk" placeholder='{"kty":"OKP","crv":"Ed25519","x":"..."}' required></textarea>
+        <button type="submit">Get keyid</button>
+        <div id="key-id-result" class="validation-result" aria-live="polite"></div>
+      </form>
+    </div>
+
+    <div class="debug-tool">
       <h2>Verify request headers</h2>
       <p>
-        Paste the signed request target and HTTP Message Signature headers here.
+        Paste the signed request target, verification JWK, and HTTP Message Signature headers here.
       </p>
       <form id="signature-header-validator">
         <div class="header-grid">
-          <label for="signature-directory-url">Directory URL</label>
-          <input id="signature-directory-url" name="directory-url" type="url" placeholder="https://example.com/.well-known/http-message-signatures-directory" required />
+          <label for="signature-jwk">JWK</label>
+          <div class="field">
+            <textarea id="signature-jwk" name="jwk" placeholder='{"kty":"OKP","crv":"Ed25519","x":"..."}' required></textarea>
+          </div>
 
           <label for="signature-method">Method</label>
-          <select id="signature-method" name="method" required>
-            <option value="GET">GET</option>
-            <option value="POST">POST</option>
-            <option value="PUT">PUT</option>
-            <option value="PATCH">PATCH</option>
-            <option value="DELETE">DELETE</option>
-            <option value="HEAD">HEAD</option>
-            <option value="OPTIONS">OPTIONS</option>
-          </select>
+          <div class="field">
+            <select id="signature-method" name="method" required>
+              <option value="GET">GET</option>
+              <option value="POST">POST</option>
+              <option value="PUT">PUT</option>
+              <option value="PATCH">PATCH</option>
+              <option value="DELETE">DELETE</option>
+              <option value="HEAD">HEAD</option>
+              <option value="OPTIONS">OPTIONS</option>
+            </select>
+          </div>
 
           <label for="signature-url">URL</label>
-          <input id="signature-url" name="url" type="url" placeholder="https://example.com/resource" required />
+          <div class="field">
+            <input id="signature-url" name="url" type="url" placeholder="https://example.com/resource" required />
+          </div>
 
           <label for="signature-header">Signature</label>
-          <textarea id="signature-header" name="signature" placeholder="sig1=:..." required></textarea>
+          <div class="field">
+            <textarea id="signature-header" name="signature" placeholder="sig1=:..." required></textarea>
+          </div>
 
           <label for="signature-agent-header">Signature-Agent</label>
-          <textarea id="signature-agent-header" name="signature-agent" placeholder='"https://example.com"'></textarea>
+          <div class="field">
+            <textarea id="signature-agent-header" name="signature-agent" placeholder='"https://example.com"'></textarea>
+            <p class="text-muted">Accepted forms: <code>"&lt;url&gt;"</code> or <code>&lt;label&gt;="&lt;url&gt;"</code>.</p>
+          </div>
 
           <label for="signature-input-header">Signature-Input</label>
-          <textarea id="signature-input-header" name="signature-input" placeholder='sig1=("@method" "@target-uri");created=...' required></textarea>
+          <div class="field">
+            <textarea id="signature-input-header" name="signature-input" placeholder='sig1=("@method" "@target-uri");created=...' required></textarea>
+          </div>
         </div>
 
         ${turnstileWidget(turnstileSiteKey)}
@@ -198,11 +230,14 @@ export const generateDebugHTML = (turnstileSiteKey: string) => `<!DOCTYPE html>
   <script>
     const form = document.getElementById("directory-validator");
     const result = document.getElementById("directory-validation-result");
+    const keyIDForm = document.getElementById("key-id-calculator");
+    const keyIDResult = document.getElementById("key-id-result");
+    const keyIDJWK = document.getElementById("key-id-jwk");
     const signatureForm = document.getElementById("signature-header-validator");
     const signatureResult = document.getElementById("signature-header-validation-result");
-    const signatureDirectoryURL = document.getElementById("signature-directory-url");
+    const signatureJWK = document.getElementById("signature-jwk");
 
-    const appendMessages = (heading, messages) => {
+    const appendMessagesTo = (target, heading, messages) => {
       if (messages.length === 0) {
         return;
       }
@@ -214,7 +249,43 @@ export const generateDebugHTML = (turnstileSiteKey: string) => `<!DOCTYPE html>
         item.textContent = message;
         list.append(item);
       }
-      result.append(paragraph, list);
+      target.append(paragraph, list);
+    };
+
+    const appendMessages = (heading, messages) => {
+      appendMessagesTo(result, heading, messages);
+    };
+
+    const directoryURLValidation = (value) => {
+      try {
+        const url = new URL(value);
+        if (!url.pathname.endsWith("${directoryPath}")) {
+          return "Directory URL path must end with ${directoryPath}";
+        }
+      } catch {
+        return "Directory URL must be valid";
+      }
+
+      return undefined;
+    };
+
+    const signatureAgentValidation = (value) => {
+      if (value.trim() === "") {
+        return undefined;
+      }
+
+      const match = value.trim().match(/^(?:[a-z*][a-z0-9_.*-]*=)?"([^"]+)"$/);
+      if (!match) {
+        return 'Signature-Agent must be "<url>" or <label>="<url>"';
+      }
+
+      try {
+        new URL(match[1]);
+      } catch {
+        return "Signature-Agent must contain a valid URL";
+      }
+
+      return undefined;
     };
 
     const validateKeys = async (directory) => {
@@ -273,6 +344,60 @@ export const generateDebugHTML = (turnstileSiteKey: string) => `<!DOCTYPE html>
       const output = document.createElement("pre");
       output.textContent = JSON.stringify(directory, null, 2);
       result.append(heading, output);
+    };
+
+    const firstDirectoryKey = (directory) => {
+      if (directory === null || typeof directory !== "object" || !Array.isArray(directory.keys) || directory.keys.length === 0) {
+        return undefined;
+      }
+      const key = directory.keys[0];
+      return key !== null && typeof key === "object" ? key : undefined;
+    };
+
+    const fillJWK = (jwk) => {
+      const value = JSON.stringify(jwk, null, 2);
+      keyIDJWK.value = value;
+      signatureJWK.value = value;
+    };
+
+    const parseJWK = (value) => {
+      let jwk;
+      try {
+        jwk = JSON.parse(value);
+      } catch {
+        throw new Error("JWK must be valid JSON");
+      }
+      if (jwk === null || typeof jwk !== "object" || Array.isArray(jwk)) {
+        throw new Error("JWK must be a JSON object");
+      }
+      return jwk;
+    };
+
+    const jwkThumbprintInput = (jwk) => {
+      switch (jwk.kty) {
+        case "EC":
+          return { crv: jwk.crv, kty: jwk.kty, x: jwk.x, y: jwk.y };
+        case "OKP":
+          return { crv: jwk.crv, kty: jwk.kty, x: jwk.x };
+        case "RSA":
+          return { e: jwk.e, kty: jwk.kty, n: jwk.n };
+        default:
+          throw new Error("Unsupported JWK kty");
+      }
+    };
+
+    const bytesToBase64URL = (bytes) => {
+      let binary = "";
+      for (const byte of bytes) {
+        binary += String.fromCharCode(byte);
+      }
+      return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
+    };
+
+    const computeJWKKeyID = async (jwk) => {
+      const input = JSON.stringify(jwkThumbprintInput(jwk));
+      const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(input));
+      return bytesToBase64URL(new Uint8Array(digest));
     };
 
     const base64ToBytes = (value) => {
@@ -366,34 +491,19 @@ export const generateDebugHTML = (turnstileSiteKey: string) => `<!DOCTYPE html>
       }
     };
 
-    const directoryFromForm = async (data) => {
-      const request = new FormData();
-      request.append("url", data.get("directory-url"));
-      request.append("cf-turnstile-response", data.get("cf-turnstile-response"));
-      const response = await fetch("/v0/api/proxy-directory", { method: "POST", body: request });
-      if (!response.ok) {
-        const body = await response.json();
-        throw new Error(body.error || "Directory fetch failed");
-      }
-      return response.json();
-    };
-
     const verifySignatureLocally = async (data) => {
-      const directory = await directoryFromForm(data);
-      const shapeValidation = validateDirectory(directory);
-      if (shapeValidation.errors.length > 0) {
-        throw new Error(shapeValidation.errors[0]);
+      const signatureAgentError = signatureAgentValidation(data.get("signature-agent") || "");
+      if (signatureAgentError !== undefined) {
+        throw new Error(signatureAgentError);
       }
-      const keyValidation = await validateKeys(directory);
-      if (keyValidation.errors.length > 0) {
-        throw new Error(keyValidation.errors[0]);
-      }
+
+      const key = parseJWK(data.get("jwk"));
+      const keyID = await computeJWKKeyID(key);
 
       const parsed = parseSignatureInputHeader(data.get("signature-input"));
       validateWebBotAuthParams(parsed.params);
-      const key = directory.keys.find((candidate) => candidate.kid === parsed.params.keyid);
-      if (!key) {
-        throw new Error("No directory key matches keyid");
+      if (parsed.params.keyid !== keyID) {
+        throw new Error("JWK keyid does not match Signature-Input keyid");
       }
 
       const url = new URL(data.get("url"));
@@ -408,6 +518,20 @@ export const generateDebugHTML = (turnstileSiteKey: string) => `<!DOCTYPE html>
       const cryptoKey = await crypto.subtle.importKey("jwk", key, { name: "Ed25519" }, true, ["verify"]);
       return crypto.subtle.verify({ name: "Ed25519" }, cryptoKey, signature, new TextEncoder().encode(signedData));
     };
+
+    keyIDForm.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      keyIDResult.textContent = "Computing keyid...";
+
+      try {
+        const jwk = parseJWK(new FormData(keyIDForm).get("jwk"));
+        const keyID = await computeJWKKeyID(jwk);
+        keyIDResult.textContent = keyID;
+        signatureJWK.value = JSON.stringify(jwk, null, 2);
+      } catch (error) {
+        keyIDResult.textContent = "Keyid calculation failed: " + (error instanceof Error ? error.message : String(error));
+      }
+    });
 
     signatureForm.addEventListener("submit", async (event) => {
       event.preventDefault();
@@ -434,8 +558,12 @@ export const generateDebugHTML = (turnstileSiteKey: string) => `<!DOCTYPE html>
       const data = new FormData(form);
       const directoryURL = data.get("url");
       result.textContent = "Checking directory...";
-      if (typeof directoryURL === "string") {
-        signatureDirectoryURL.value = directoryURL;
+
+      const directoryError = directoryURLValidation(directoryURL);
+      if (directoryError !== undefined) {
+        result.replaceChildren();
+        appendMessages("Directory check failed", [directoryError]);
+        return;
       }
 
       try {
@@ -477,6 +605,10 @@ export const generateDebugHTML = (turnstileSiteKey: string) => `<!DOCTYPE html>
         appendMessages("Warnings", warnings);
         if (typeof directory !== "undefined") {
           appendDirectory(directory);
+          const key = firstDirectoryKey(directory);
+          if (key !== undefined) {
+            fillJWK(key);
+          }
         }
       } catch {
         result.textContent = "Directory check failed.";

--- a/examples/verification-workers/src/html.ts
+++ b/examples/verification-workers/src/html.ts
@@ -16,17 +16,7 @@ function escapeAttribute(value: string): string {
 	return value.replaceAll("&", "&amp;").replaceAll('"', "&quot;");
 }
 
-export const generateHTML = (
-	status: boolean | undefined,
-	turnstileSiteKey: string
-) => `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>Identify Bots with HTTP Message Signatures</title>
-  <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
-  <style>* {
+const theme = `<style>* {
   margin: 0;
   padding: 0;
   border: none;
@@ -165,12 +155,13 @@ table > thead > tr > th {
   padding: 5px;
 }
 
-.form-inline {
+.form-inline,
+form {
   padding: 1.5rem 3rem 3rem;
   background-color: #DDE8EF;
 }
 label { display: block; }
-input, button {
+input, select, textarea, button {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -183,12 +174,19 @@ input {
   padding: 6px 12px;
   width: 45%;
 }
+select {
+  background-color: white;
+  border: 1px solid #999;
+  box-sizing: border-box;
+  padding: 8px 10px;
+  width: 100%;
+}
 button {
   color: white;
-  background-color: #F1592A;
-  border-radius: 6px;
+  background-color: #2F6F8F;
   padding: 6px 12px;
 }
+button:hover { background-color: #255A74; }
 button:hover,
 button:focus {
   outline: none;
@@ -197,9 +195,10 @@ button:focus {
 button:active {
   box-shadow: inset 0 1px 1px 1px rgba(0,0,0,.4);
 }
-input[type="url"] {
+input[type="url"],
+input[type="text"],
+textarea {
   border: 1px solid #999;
-  border-radius: 6px;
   box-sizing: border-box;
   display: block;
   font: inherit;
@@ -207,6 +206,31 @@ input[type="url"] {
   max-width: 720px;
   padding: 8px 10px;
   width: 100%;
+}
+textarea {
+  min-height: 7rem;
+  resize: vertical;
+}
+.debug-tool {
+  margin-bottom: 3rem;
+}
+.header-grid {
+  display: grid;
+  grid-template-columns: 16rem minmax(0, 1fr);
+  gap: 1rem 1.5rem;
+  align-items: start;
+}
+.header-grid label {
+  font-weight: 600;
+  margin-top: 1.7rem;
+}
+.header-grid textarea {
+  margin-bottom: 0;
+}
+.header-grid input,
+.header-grid select {
+  margin-bottom: 0;
+  max-width: 720px;
 }
 .validation-result {
   margin-top: 0.75rem;
@@ -233,7 +257,24 @@ footer {
   font-size: 13px;
   color: #888;
 }
-</style>
+@media (max-width: 640px) {
+  .header-grid {
+    grid-template-columns: 1fr;
+    gap: 0;
+  }
+  .header-grid label {
+    margin-top: 1rem;
+  }
+}
+</style>`;
+
+export const generateHTML = (status: boolean | undefined) => `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Identify Bots with HTTP Message Signatures</title>
+  ${theme}
 </head>
 <body>
   <header id="top" ${status !== undefined ? `class="${status ? "success" : "failure"}"` : ""}>
@@ -301,21 +342,9 @@ footer {
       </ul>
     </p>
 
-    <h2>Validate your key directory</h2>
-    <p>
-      Paste the full HTTPS URL for a <code>/.well-known/http-message-signatures-directory</code> endpoint to check whether it returns a usable directory.
-    </p>
-    <form id="directory-validator">
-      <label for="directory-url">Directory URL</label>
-      <input id="directory-url" name="url" type="url" placeholder="https://example.com/.well-known/http-message-signatures-directory" required />
-      <div class="cf-turnstile" data-sitekey="${escapeAttribute(turnstileSiteKey)}"></div>
-      <button type="submit">Validate directory</button>
-      <div id="directory-validation-result" class="validation-result" aria-live="polite"></div>
-    </form>
-
     <h2>It's hard to debug. How can this website help?</h2>
     <p>
-    This website expose an endpoint dropping incoming request headers on <a>/debug</a>
+      Use the <a href="/debug">debug page</a> to validate key directories and signature headers.
     </p>
 
     <h2>I have comments and want to contribute. Where do I go?</h2>
@@ -329,9 +358,88 @@ footer {
     To contribute to the standard discussion, the current draft is hosted on <a href="https://github.com/thibmeu/http-message-signatures-directory">thibmeu/http-message-signatures-directory</a>, and is being discussed on <a href="https://mailarchive.ietf.org/arch/browse/web-bot-auth/">web-bot-auth</a> IETF mailing list.
     </p>
   </section>
+</body>
+</html>`;
+
+export const generateDebugHTML = (turnstileSiteKey: string) => `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Debug HTTP Message Signatures</title>
+  <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
+  ${theme}
+</head>
+<body>
+  <header id="top">
+    <h1>Debug HTTP Message Signatures</h1>
+    <h3>Validate key directories and inspect signature inputs.</h3>
+  </header>
+  <section>
+    <p>
+      This page collects debugging tools for Web Bot Auth implementations. Start by validating the key directory. Header verification is reserved for a later step.
+    </p>
+
+    <div class="debug-tool">
+      <h2>Validate key directory</h2>
+      <p>
+        Paste the full HTTPS URL for a <code>/.well-known/http-message-signatures-directory</code> endpoint to check whether it returns a usable directory.
+      </p>
+      <form id="directory-validator">
+        <label for="directory-url">Directory URL</label>
+        <input id="directory-url" name="url" type="url" placeholder="https://example.com/.well-known/http-message-signatures-directory" required />
+        <div class="cf-turnstile" data-sitekey="${escapeAttribute(turnstileSiteKey)}"></div>
+        <button type="submit">Validate directory</button>
+        <div id="directory-validation-result" class="validation-result" aria-live="polite"></div>
+      </form>
+    </div>
+
+    <div class="debug-tool">
+      <h2>Verify request headers</h2>
+      <p>
+        Paste the signed request target and HTTP Message Signature headers here.
+      </p>
+      <form id="signature-header-validator">
+        <div class="header-grid">
+          <label for="signature-directory-url">Directory URL</label>
+          <input id="signature-directory-url" name="directory-url" type="url" placeholder="https://example.com/.well-known/http-message-signatures-directory" required />
+
+          <label for="signature-method">Method</label>
+          <select id="signature-method" name="method" required>
+            <option value="GET">GET</option>
+            <option value="POST">POST</option>
+            <option value="PUT">PUT</option>
+            <option value="PATCH">PATCH</option>
+            <option value="DELETE">DELETE</option>
+            <option value="HEAD">HEAD</option>
+            <option value="OPTIONS">OPTIONS</option>
+          </select>
+
+          <label for="signature-url">URL</label>
+          <input id="signature-url" name="url" type="url" placeholder="https://example.com/resource" required />
+
+          <label for="signature-header">Signature</label>
+          <textarea id="signature-header" name="signature" placeholder="sig1=:..." required></textarea>
+
+          <label for="signature-agent-header">Signature-Agent</label>
+          <textarea id="signature-agent-header" name="signature-agent" placeholder='"https://example.com"'></textarea>
+
+          <label for="signature-input-header">Signature-Input</label>
+          <textarea id="signature-input-header" name="signature-input" placeholder='sig1=("@method" "@target-uri");created=...' required></textarea>
+        </div>
+
+        <div class="cf-turnstile" data-sitekey="${escapeAttribute(turnstileSiteKey)}"></div>
+
+        <button type="submit">Verify headers</button>
+        <div id="signature-header-validation-result" class="validation-result" aria-live="polite"></div>
+      </form>
+    </div>
+  </section>
   <script>
     const form = document.getElementById("directory-validator");
     const result = document.getElementById("directory-validation-result");
+    const signatureForm = document.getElementById("signature-header-validator");
+    const signatureResult = document.getElementById("signature-header-validation-result");
 
     const appendMessages = (heading, messages) => {
       if (messages.length === 0) {
@@ -397,6 +505,162 @@ footer {
 
       return { errors, warnings: [] };
     };
+
+    const base64ToBytes = (value) => {
+      const decoded = atob(value);
+      const bytes = new Uint8Array(decoded.length);
+      for (let index = 0; index < decoded.length; index += 1) {
+        bytes[index] = decoded.charCodeAt(index);
+      }
+      return bytes;
+    };
+
+    const parseSignatureHeader = (key, header) => {
+      const match = header.match(/^([\\w-]+)=:([A-Za-z0-9+/=]+):$/);
+      if (!match) {
+        throw new Error("Invalid Signature header");
+      }
+      if (match[1] !== key) {
+        throw new Error("Signature label does not match Signature-Input label");
+      }
+      return base64ToBytes(match[2]);
+    };
+
+    const parseSignatureInputHeader = (header) => {
+      const match = header.match(/^([\\w-]+)=\\(([^)]*)\\)(.*)$/);
+      if (!match) {
+        throw new Error("Invalid Signature-Input header");
+      }
+
+      const components = [];
+      for (const component of match[2].matchAll(/"([^"]+)"/g)) {
+        components.push(component[1].toLowerCase());
+      }
+      if (components.length === 0) {
+        throw new Error("Signature-Input must contain at least one component");
+      }
+
+      const params = {};
+      for (const parameter of match[3].matchAll(/;([^=]+)=("[^"]*"|[^;]+)/g)) {
+        const name = parameter[1];
+        const rawValue = parameter[2];
+        const value = rawValue.startsWith('"') ? rawValue.slice(1, -1) : rawValue;
+        params[name] = name === "created" || name === "expires" ? Number.parseInt(value, 10) : value;
+      }
+
+      return { key: match[1], components, params, input: header.replace(/^[^=]+=/, "") };
+    };
+
+    const requestTarget = (url) => url.pathname + url.search;
+
+    const componentValue = (component, request, headers) => {
+      switch (component) {
+        case "@method":
+          return request.method.toUpperCase();
+        case "@target-uri":
+          return request.url.toString();
+        case "@authority": {
+          const port = request.url.port;
+          const includePort = port !== "" && port !== "80" && port !== "443";
+          return request.url.hostname + (includePort ? ":" + port : "");
+        }
+        case "@scheme":
+          return request.url.protocol.slice(0, -1);
+        case "@request-target":
+          return requestTarget(request.url);
+        case "@path":
+          return request.url.pathname;
+        case "@query":
+          return request.url.search;
+        default:
+          return headers[component] || "";
+      }
+    };
+
+    const buildSignedData = (parsed, request, headers) => {
+      const parts = parsed.components.map((component) => '"' + component + '": ' + componentValue(component, request, headers));
+      parts.push('"@signature-params": ' + parsed.input);
+      return parts.join("\n");
+    };
+
+    const validateWebBotAuthParams = (params) => {
+      if (params.tag !== "web-bot-auth") {
+        throw new Error("tag must be 'web-bot-auth'");
+      }
+      if (!params.keyid) {
+        throw new Error("keyid MUST be defined");
+      }
+      const now = Date.now() / 1000;
+      if (typeof params.created === "number" && params.created > now) {
+        throw new Error("created in the future");
+      }
+      if (typeof params.expires === "number" && params.expires < now) {
+        throw new Error("signature has expired");
+      }
+    };
+
+    const directoryFromForm = async (data) => {
+      const request = new FormData();
+      request.append("url", data.get("directory-url"));
+      request.append("cf-turnstile-response", data.get("cf-turnstile-response"));
+      const response = await fetch("/v0/api/proxy-directory", { method: "POST", body: request });
+      if (!response.ok) {
+        const body = await response.json();
+        throw new Error(body.error || "Directory fetch failed");
+      }
+      return response.json();
+    };
+
+    const verifySignatureLocally = async (data) => {
+      const directory = await directoryFromForm(data);
+      const shapeValidation = validateDirectory(directory);
+      if (shapeValidation.errors.length > 0) {
+        throw new Error(shapeValidation.errors[0]);
+      }
+      const keyValidation = await validateKeys(directory);
+      if (keyValidation.errors.length > 0) {
+        throw new Error(keyValidation.errors[0]);
+      }
+
+      const parsed = parseSignatureInputHeader(data.get("signature-input"));
+      validateWebBotAuthParams(parsed.params);
+      const key = directory.keys.find((candidate) => candidate.kid === parsed.params.keyid);
+      if (!key) {
+        throw new Error("No directory key matches keyid");
+      }
+
+      const url = new URL(data.get("url"));
+      const headers = {
+        "signature": data.get("signature"),
+        "signature-agent": data.get("signature-agent") || "",
+        "signature-input": data.get("signature-input"),
+      };
+      const request = { method: data.get("method"), url };
+      const signedData = buildSignedData(parsed, request, headers);
+      const signature = parseSignatureHeader(parsed.key, data.get("signature"));
+      const cryptoKey = await crypto.subtle.importKey("jwk", key, { name: "Ed25519" }, true, ["verify"]);
+      return crypto.subtle.verify({ name: "Ed25519" }, cryptoKey, signature, new TextEncoder().encode(signedData));
+    };
+
+    signatureForm.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const data = new FormData(signatureForm);
+      signatureResult.textContent = "Verifying signature...";
+
+      try {
+        if (await verifySignatureLocally(data)) {
+          signatureResult.textContent = "Signature is valid.";
+        } else {
+          signatureResult.textContent = "Signature check failed: invalid signature";
+        }
+      } catch (error) {
+        signatureResult.textContent = "Signature check failed: " + (error instanceof Error ? error.message : String(error));
+      } finally {
+        if (window.turnstile) {
+          window.turnstile.reset("#signature-header-validator .cf-turnstile");
+        }
+      }
+    });
 
     form.addEventListener("submit", async (event) => {
       event.preventDefault();

--- a/examples/verification-workers/src/html.ts
+++ b/examples/verification-workers/src/html.ts
@@ -373,31 +373,78 @@ footer {
       return { errors, warnings };
     };
 
+    const validateDirectory = (directory) => {
+      const errors = [];
+      if (directory === null || typeof directory !== "object") {
+        return { errors: ["Directory must be a JSON object"], warnings: [] };
+      }
+
+      if (!Array.isArray(directory.keys)) {
+        errors.push("Directory must include a keys array");
+      } else if (directory.keys.length === 0) {
+        errors.push("Directory keys array must not be empty");
+      } else {
+        for (const [index, key] of directory.keys.entries()) {
+          if (key === null || typeof key !== "object") {
+            errors.push("keys[" + index + "] must be a JSON object");
+          }
+        }
+      }
+
+      if (directory.purpose !== undefined && typeof directory.purpose !== "string") {
+        errors.push("Directory purpose must be a string when present");
+      }
+
+      return { errors, warnings: [] };
+    };
+
     form.addEventListener("submit", async (event) => {
       event.preventDefault();
       const data = new FormData(form);
       result.textContent = "Checking directory...";
 
       try {
-        const response = await fetch("/v0/api/validate-directory", { method: "POST", body: data });
-        const body = await response.json();
-        if (body.ok) {
-          const keyValidation = await validateKeys(body.directory);
-          body.errors.push(...keyValidation.errors);
-          body.warnings.push(...keyValidation.warnings);
-          body.ok = body.errors.length === 0;
+        const response = await fetch("/v0/api/proxy-directory", { method: "POST", body: data });
+        const errors = [];
+        const warnings = [];
+
+        if (!response.ok) {
+          const body = await response.json();
+          errors.push(body.error || "Directory fetch failed");
+        } else {
+          const contentType = response.headers.get("Content-Type");
+          const mediaType = contentType ? contentType.split(";", 1)[0].trim().toLowerCase() : "";
+          if (mediaType !== "application/http-message-signatures-directory+json" && mediaType !== "application/json") {
+            warnings.push("Directory returned unexpected Content-Type " + (contentType || "none"));
+          }
+
+          const directory = await response.json();
+          const shapeValidation = validateDirectory(directory);
+          errors.push(...shapeValidation.errors);
+          warnings.push(...shapeValidation.warnings);
+
+          if (errors.length === 0) {
+            const keyValidation = await validateKeys(directory);
+            errors.push(...keyValidation.errors);
+            warnings.push(...keyValidation.warnings);
+          }
         }
+
         result.replaceChildren();
-        if (body.ok) {
+        if (errors.length === 0) {
           const paragraph = document.createElement("p");
           paragraph.textContent = "Directory looks valid.";
           result.append(paragraph);
         } else {
-          appendMessages("Directory check failed", body.errors);
+          appendMessages("Directory check failed", errors);
         }
-        appendMessages("Warnings", body.warnings);
+        appendMessages("Warnings", warnings);
       } catch {
         result.textContent = "Directory check failed.";
+      } finally {
+        if (window.turnstile) {
+          window.turnstile.reset("#directory-validator .cf-turnstile");
+        }
       }
     });
   </script>

--- a/examples/verification-workers/src/html.ts
+++ b/examples/verification-workers/src/html.ts
@@ -12,12 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const generateHTML = (status?: boolean) => `<!DOCTYPE html>
+function escapeAttribute(value: string): string {
+	return value.replaceAll("&", "&amp;").replaceAll('"', "&quot;");
+}
+
+export const generateHTML = (
+	status: boolean | undefined,
+	turnstileSiteKey: string
+) => `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Identify Bots with HTTP Message Signatures</title>
+  <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
   <style>* {
   margin: 0;
   padding: 0;
@@ -189,6 +197,26 @@ button:focus {
 button:active {
   box-shadow: inset 0 1px 1px 1px rgba(0,0,0,.4);
 }
+input[type="url"] {
+  border: 1px solid #999;
+  border-radius: 6px;
+  box-sizing: border-box;
+  display: block;
+  font: inherit;
+  margin: 0.5rem 0 1rem;
+  max-width: 720px;
+  padding: 8px 10px;
+  width: 100%;
+}
+.validation-result {
+  margin-top: 0.75rem;
+}
+.validation-result ul {
+  padding-left: 1.5rem;
+}
+.validation-result li {
+  margin-bottom: 0.25rem;
+}
 
 .question-list {
   margin-bottom: 2rem;
@@ -273,6 +301,18 @@ footer {
       </ul>
     </p>
 
+    <h2>Validate your key directory</h2>
+    <p>
+      Paste the full HTTPS URL for a <code>/.well-known/http-message-signatures-directory</code> endpoint to check whether it returns a usable directory.
+    </p>
+    <form id="directory-validator">
+      <label for="directory-url">Directory URL</label>
+      <input id="directory-url" name="url" type="url" placeholder="https://example.com/.well-known/http-message-signatures-directory" required />
+      <div class="cf-turnstile" data-sitekey="${escapeAttribute(turnstileSiteKey)}"></div>
+      <button type="submit">Validate directory</button>
+      <div id="directory-validation-result" class="validation-result" aria-live="polite"></div>
+    </form>
+
     <h2>It's hard to debug. How can this website help?</h2>
     <p>
     This website expose an endpoint dropping incoming request headers on <a>/debug</a>
@@ -289,9 +329,58 @@ footer {
     To contribute to the standard discussion, the current draft is hosted on <a href="https://github.com/thibmeu/http-message-signatures-directory">thibmeu/http-message-signatures-directory</a>, and is being discussed on <a href="https://mailarchive.ietf.org/arch/browse/web-bot-auth/">web-bot-auth</a> IETF mailing list.
     </p>
   </section>
+  <script>
+    const form = document.getElementById("directory-validator");
+    const result = document.getElementById("directory-validation-result");
+
+    const appendMessages = (heading, messages) => {
+      if (messages.length === 0) {
+        return;
+      }
+      const paragraph = document.createElement("p");
+      paragraph.textContent = heading;
+      const list = document.createElement("ul");
+      for (const message of messages) {
+        const item = document.createElement("li");
+        item.textContent = message;
+        list.append(item);
+      }
+      result.append(paragraph, list);
+    };
+
+    form.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const data = new FormData(form);
+      const turnstileToken = data.get("cf-turnstile-response");
+      result.textContent = "Checking directory...";
+
+      try {
+        const response = await fetch("/v0/api/validate-directory", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            url: data.get("url"),
+            turnstileToken,
+          }),
+        });
+        const body = await response.json();
+        result.replaceChildren();
+        if (body.ok) {
+          const paragraph = document.createElement("p");
+          paragraph.textContent = "Directory looks valid.";
+          result.append(paragraph);
+        } else {
+          appendMessages("Directory check failed", body.errors);
+        }
+        appendMessages("Warnings", body.warnings);
+      } catch (_e) {
+        result.textContent = "Directory check failed.";
+      } finally {
+        if (window.turnstile) {
+          window.turnstile.reset("#directory-validator .cf-turnstile");
+        }
+      }
+    });
+  </script>
 </body>
 </html>`;
-
-export const neutralHTML = generateHTML();
-export const invalidHTML = generateHTML(false);
-export const validHTML = generateHTML(true);

--- a/examples/verification-workers/src/html.ts
+++ b/examples/verification-workers/src/html.ts
@@ -348,22 +348,45 @@ footer {
       result.append(paragraph, list);
     };
 
+    const validateKeys = async (directory) => {
+      const errors = [];
+      const warnings = [];
+      let imported = 0;
+
+      for (const [index, key] of directory.keys.entries()) {
+        if (key.kty !== "OKP" || key.crv !== "Ed25519") {
+          warnings.push("keys[" + index + "] is not an Ed25519 OKP key");
+          continue;
+        }
+        try {
+          await crypto.subtle.importKey("jwk", key, { name: "Ed25519" }, true, ["verify"]);
+          imported += 1;
+        } catch {
+          errors.push("keys[" + index + "] could not be imported as Ed25519");
+        }
+      }
+
+      if (imported === 0) {
+        errors.push("Directory does not contain an importable Ed25519 key");
+      }
+
+      return { errors, warnings };
+    };
+
     form.addEventListener("submit", async (event) => {
       event.preventDefault();
       const data = new FormData(form);
-      const turnstileToken = data.get("cf-turnstile-response");
       result.textContent = "Checking directory...";
 
       try {
-        const response = await fetch("/v0/api/validate-directory", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            url: data.get("url"),
-            turnstileToken,
-          }),
-        });
+        const response = await fetch("/v0/api/validate-directory", { method: "POST", body: data });
         const body = await response.json();
+        if (body.ok) {
+          const keyValidation = await validateKeys(body.directory);
+          body.errors.push(...keyValidation.errors);
+          body.warnings.push(...keyValidation.warnings);
+          body.ok = body.errors.length === 0;
+        }
         result.replaceChildren();
         if (body.ok) {
           const paragraph = document.createElement("p");
@@ -373,12 +396,8 @@ footer {
           appendMessages("Directory check failed", body.errors);
         }
         appendMessages("Warnings", body.warnings);
-      } catch (_e) {
+      } catch {
         result.textContent = "Directory check failed.";
-      } finally {
-        if (window.turnstile) {
-          window.turnstile.reset("#directory-validator .cf-turnstile");
-        }
       }
     });
   </script>

--- a/examples/verification-workers/src/index-html.ts
+++ b/examples/verification-workers/src/index-html.ts
@@ -1,0 +1,299 @@
+// Copyright 2025 Cloudflare, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export const theme = `<style>* {
+  margin: 0;
+  padding: 0;
+  border: none;
+}
+
+html { font-size: 62.5%; }
+
+body {
+  margin: 0;
+  font-family: open sans, HelveticaNeue, Helvetica Neue, Helvetica, Arial, sans-serif;
+  font-size: 1.5em;
+  font-weight: 400;
+  line-height: 1.6;
+  color: #222;
+}
+
+h1 {
+  font-family: Montserrat, helvetica, arial, sans-serif;
+  font-size: 6rem;
+  font-weight: 700;
+  line-height: 6.5rem;
+  text-align: center;
+  color: black;
+}
+h3 {
+  font-size: 2rem;
+  font-weight: 600;
+  line-height: 2.4rem;
+  padding-top: 3rem;
+  padding-bottom: .5rem;
+}
+h4 {
+  font-size: 1.6rem;
+  font-weight: 600;
+  line-height: 2.6rem;
+  padding: 1.4rem 0 1rem;
+}
+p {
+  font-size: 1.6rem;
+  padding-bottom: 1.3rem;
+}
+a { color: #125CCA; }
+a:hover { color: #3BA3BB; }
+
+header {
+  position: relative;
+  width: 100%;
+  padding: 40px 0 65px;
+  background-color: #DDE8EF;
+}
+
+header.success {
+  background-color: #B3E1EF;
+}
+
+header.failure {
+  background-color: #d44613;
+}
+
+header h3 {
+  text-align: center;
+}
+
+.toc li {
+  display: inline-block;
+  position: relative;
+  width: 49%;
+  box-sizing: border-box;
+  background-color: #DDE8EF;
+  list-style-type: none;
+  text-align: center;
+}
+.toc li:not(:first-of-type) {
+  margin-left: 2%;
+}
+.toc li:hover { background-color: #B3E1EF; }
+.toc a {
+  display: inline-block;
+  width: 100%;
+  padding: 2px 0 3px;
+  font-weight: 600;
+  text-decoration: none;
+  color: #464646;
+}
+
+section {
+  position: relative;
+  margin: 20px 0;
+  padding: 0 20px;
+}
+section > * {
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+.illustrated {  }
+img {
+  display: block;
+  margin: 0 auto;
+  padding: 2rem 0;
+}
+.illustration {
+  max-height: 350px;
+  max-width: 100%;
+}
+
+#intro {
+  padding-top: 65px;
+}
+#intro p {
+  font-weight: 400;
+  font-size: 1.8rem;
+  line-height: 3rem;
+  padding-top: 2rem;
+}
+
+/*table style from bootstrap*/
+table {
+  width: 100%;
+  margin-bottom: 20px;
+  padding: 1rem 0;
+}
+table th,
+table td {
+  padding: 8px;
+  line-height: 1.42857143;
+  vertical-align: top;
+  border-bottom: 1px solid #ddd;
+}
+table > thead > tr > th {
+  vertical-align: bottom;
+  border-bottom: 2px solid #ddd;
+}
+.table-condensed th,
+.table-condensed td {
+  padding: 5px;
+}
+
+.form-inline {
+  padding: 1.5rem 3rem 3rem;
+  background-color: #DDE8EF;
+}
+label { display: block; }
+input, button {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  font-family: open sans, sans-serif;
+  font-size: 16px;
+  font-weight: 400;
+  margin-top: 1rem;
+}
+input {
+  padding: 6px 12px;
+  width: 45%;
+}
+button {
+  color: white;
+  background-color: #F1592A;
+  border-radius: 6px;
+  padding: 6px 12px;
+}
+button:hover,
+button:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px #3BA3BD;
+}
+button:active {
+  box-shadow: inset 0 1px 1px 1px rgba(0,0,0,.4);
+}
+
+.question-list {
+  margin-bottom: 2rem;
+}
+.question-list li {
+  margin-left: 1.8rem;
+}
+
+footer {
+  border-top: 1px solid #ccc;
+  padding: 1rem 3rem;
+}
+.text-muted {
+  font-size: 13px;
+  color: #888;
+}
+</style>`;
+
+const generateHTML = (status?: boolean) => `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Identify Bots with HTTP Message Signatures</title>
+  ${theme}
+</head>
+<body>
+  <header id="top" ${status !== undefined ? `class="${status ? "success" : "failure"}"` : ""}>
+    <h1>Identify Bots with HTTP Message Signatures</h1>
+    <h3>
+    ${status === undefined ? "Your browser does not support HTTP Message Signatures" : ""}
+    ${status === false ? "The Signature you sent does not validate against test public key" : ""}
+    ${status === true ? "You successfully authenticated as owning the test public key" : ""}
+    </h3>
+  </header>
+  <section>
+    <p>
+      HTTP Message Signatures are a mechanism to create, encode, and verify signatures over components of an HTTP message.
+      They are standardised by the IETF in <a href="https://datatracker.ietf.org/doc/html/rfc9421">RFC 9421</a>.
+
+      This website validates the presence of such signature as defined in <a href="https://github.com/thibmeu/http-message-signatures-directory">draft-meunier-web-bot-auth-architecture</a>.
+    </p>
+    <p>
+      This website checks for an Ed25519 signature on incoming request. They should be signed by a test public key defined in <a href="https://datatracker.ietf.org/doc/html/rfc9421#name-example-ed25519-test-key">Appendix B.1.4 of RFC 9421</a>.
+    </p>
+
+    <h2>Why do platforms and websites need this?</h2>
+    <p>
+      As a platform provider, I would like to ensure websites are able to identify requests originating from my service.
+      At the moment, I share IP ranges, but this is long to deploy, cumbersome to maintain, and costly, especially with the multiplication of services, and the need to localise outgoing traffic with a forward proxy.
+      It's even more pressing as I onboard multiple companies on my platform that need to have their own identity.
+      And user agent headers do not have any integrity protection.
+    </p>
+    <p>
+      It's time for websites to know who's calling, and for platforms to prove it.
+    </p>
+
+    <h2>How to retrieve the public key used by this website</h2>
+    <p>
+      We define a key directory accessible under <a>/.well-known/http-message-signatures-directory</a>
+
+      The directory looks as follow
+      </p>
+      <pre>{
+  "keys": [
+    {
+      "kid":"poqkLGiymh_W0uP6PZFw-dvez3QJT5SolqXBCW38r0U",
+      "kty":"OKP",
+      "crv":"Ed25519",
+      "x":"JrQLj5P_89iXES9-vFgrIy29clF9CC_oPPsw3c5D0bs",
+      "nbf": 1743465600000
+    }
+  ]
+}
+      </pre>
+
+      <p>
+      Parameters are defined as follow:
+
+      <ul>
+        <li><strong>keys</strong>: an array of serialised JSON Web Key defined by <a href="https://www.rfc-editor.org/rfc/rfc7517.html">RFC 7517</a>
+          <ul style="padding-left:1em">
+          <li><strong>kid</strong>: JWK Thumbprint as defined in <a href="https://www.rfc-editor.org/rfc/rfc7638.html">RFC 7638</a></li>
+          <li><strong>nbf</strong>: start of the validity of the public key as a unix timestamp in milliseconds defined by <a href="https://www.rfc-editor.org/rfc/rfc7519.html">RFC 7519</a></li>
+          <li><strong>exp</strong>: end of the validity of the public key as a unix timestamp in milliseconds defined by <a href="https://www.rfc-editor.org/rfc/rfc7519.html">RFC 7519</a></li>
+          <li><strong>...jwk</strong>: JWK public cryptographic material</li>
+          </ul>
+        </li>
+        <li><strong>purpose</strong>: represents what a signature means. Examples could be the draft for <a href="https://github.com/martinthomson/sup-ai">Short usage preference proposed</a>.</li>
+      </ul>
+    </p>
+
+    <h2>It's hard to debug. How can this website help?</h2>
+    <p>
+      Use the <a href="/debug">debug page</a> to validate key directories and signature headers.
+    </p>
+
+    <h2>I have comments and want to contribute. Where do I go?</h2>
+    <p>
+    First off, this is fantastic news!
+    </p>
+    <p>
+    To contribute to this website, you can go to <a href="https://github.com/cloudflareresearch/web-bot-auth">cloudflareresearch/web-bot-auth</a>.
+    </p>
+    <p>
+    To contribute to the standard discussion, the current draft is hosted on <a href="https://github.com/thibmeu/http-message-signatures-directory">thibmeu/http-message-signatures-directory</a>, and is being discussed on <a href="https://mailarchive.ietf.org/arch/browse/web-bot-auth/">web-bot-auth</a> IETF mailing list.
+    </p>
+  </section>
+</body>
+</html>`;
+
+export const neutralHTML = generateHTML();
+export const invalidHTML = generateHTML(false);
+export const validHTML = generateHTML(true);

--- a/examples/verification-workers/src/index.ts
+++ b/examples/verification-workers/src/index.ts
@@ -192,18 +192,20 @@ export default {
 
 		if (url.pathname.startsWith(HTTP_MESSAGE_SIGNATURES_DIRECTORY)) {
 			const directory = await getExampleDirectory();
-
-			const signedHeaders = await directoryResponseHeaders(
-				request,
-				[await getSigner()],
-				{ created: new Date(), expires: new Date(Date.now() + 300_000) }
-			);
-			return new Response(JSON.stringify(directory), {
+			const response = new Response(JSON.stringify(directory), {
 				headers: {
-					...signedHeaders,
 					"content-type": MediaType.HTTP_MESSAGE_SIGNATURES_DIRECTORY,
 				},
 			});
+
+			const signedHeaders = await directoryResponseHeaders(
+				{ request, response },
+				[await getSigner()],
+				{ created: new Date(), expires: new Date(Date.now() + 300_000) }
+			);
+			response.headers.set("Signature", signedHeaders.Signature);
+			response.headers.set("Signature-Input", signedHeaders["Signature-Input"]);
+			return response;
 		}
 
 		const status = await verifySignature(env, request);

--- a/examples/verification-workers/src/index.ts
+++ b/examples/verification-workers/src/index.ts
@@ -24,9 +24,71 @@ import {
 	signatureHeaders,
 	verify,
 } from "web-bot-auth";
-import { invalidHTML, neutralHTML, validHTML } from "./html";
+import { generateHTML } from "./html";
 import jwk from "../../rfc9421-keys/ed25519.json" assert { type: "json" };
 import { Ed25519Signer } from "web-bot-auth/crypto";
+
+const DIRECTORY_FETCH_TIMEOUT_MS = 5_000;
+const DIRECTORY_RESPONSE_MAX_BYTES = 64_000;
+const TURNSTILE_VERIFY_URL =
+	"https://challenges.cloudflare.com/turnstile/v0/siteverify";
+
+interface ValidationResult {
+	ok: boolean;
+	errors: string[];
+	warnings: string[];
+}
+
+function errorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+function getProperty(value: unknown, name: string): unknown {
+	if (value === null || typeof value !== "object") {
+		return undefined;
+	}
+	for (const [key, property] of Object.entries(value)) {
+		if (key === name) {
+			return property;
+		}
+	}
+	return undefined;
+}
+
+function getStringProperty(value: unknown, name: string): string | undefined {
+	const property = getProperty(value, name);
+	return typeof property === "string" ? property : undefined;
+}
+
+function getBooleanProperty(value: unknown, name: string): boolean | undefined {
+	const property = getProperty(value, name);
+	return typeof property === "boolean" ? property : undefined;
+}
+
+function validationResponse(result: ValidationResult, status = 200): Response {
+	return Response.json(result, { status });
+}
+
+function errorResponse(errors: string[], status = 400): Response {
+	return validationResponse({ ok: false, errors, warnings: [] }, status);
+}
+
+function getTurnstileSiteKey(env: Env): string {
+	return getStringProperty(env, "TURNSTILE_SITE_KEY") ?? "";
+}
+
+function base64urlDecodedLength(value: string): number | undefined {
+	if (!/^[A-Za-z0-9_-]+$/.test(value)) {
+		return undefined;
+	}
+	try {
+		const padding = "=".repeat((4 - (value.length % 4)) % 4);
+		return atob(value.replaceAll("-", "+").replaceAll("_", "/") + padding)
+			.length;
+	} catch {
+		return undefined;
+	}
+}
 
 async function getExampleDirectory(): Promise<Directory> {
 	const key = {
@@ -51,7 +113,7 @@ async function fetchDirectory(signatureAgent: string): Promise<Directory> {
 	let parsed: string;
 	try {
 		parsed = JSON.parse(signatureAgent);
-	} catch (_e) {
+	} catch {
 		const e = new Error(
 			`Failed to validate Signature-Agent header: ${signatureAgent}`
 		);
@@ -87,6 +149,258 @@ async function fetchDirectory(signatureAgent: string): Promise<Directory> {
 	return response.json();
 }
 
+async function validateTurnstile(
+	env: Env,
+	token: string,
+	remoteIP: string | null
+): Promise<boolean> {
+	const formData = new FormData();
+	formData.append("secret", env.TURNSTILE_SECRET_KEY);
+	formData.append("response", token);
+	if (remoteIP !== null) {
+		formData.append("remoteip", remoteIP);
+	}
+
+	let response: Response;
+	try {
+		response = await fetch(TURNSTILE_VERIFY_URL, {
+			body: formData,
+			method: "POST",
+		});
+	} catch {
+		return false;
+	}
+
+	if (!response.ok) {
+		return false;
+	}
+
+	try {
+		const body: unknown = await response.json();
+		return getBooleanProperty(body, "success") === true;
+	} catch {
+		return false;
+	}
+}
+
+function hasExpectedRequestContext(request: Request): boolean {
+	const requestOrigin = new URL(request.url).origin;
+	if (request.headers.get("Origin") !== requestOrigin) {
+		return false;
+	}
+
+	const referer = request.headers.get("Referer");
+	if (referer === null) {
+		return false;
+	}
+	try {
+		if (new URL(referer).origin !== requestOrigin) {
+			return false;
+		}
+	} catch {
+		return false;
+	}
+
+	return (
+		request.headers.get("Sec-Fetch-Site") === "same-origin" &&
+		request.headers.get("Sec-Fetch-Mode") === "cors" &&
+		request.headers.get("Sec-Fetch-Dest") === "empty"
+	);
+}
+
+function validateDirectoryURL(url: string): URL | Response {
+	let parsed: URL;
+	try {
+		parsed = new URL(url);
+	} catch {
+		return errorResponse(["URL must be valid"]);
+	}
+
+	if (parsed.protocol !== "https:") {
+		return errorResponse(['Directory URL must use "https:"']);
+	}
+	if (parsed.username !== "" || parsed.password !== "") {
+		return errorResponse(["Directory URL must not include credentials"]);
+	}
+	if (parsed.port !== "") {
+		return errorResponse(["Directory URL must not use a custom port"]);
+	}
+	if (parsed.pathname !== HTTP_MESSAGE_SIGNATURES_DIRECTORY) {
+		return errorResponse([
+			`Directory URL path must be ${HTTP_MESSAGE_SIGNATURES_DIRECTORY}`,
+		]);
+	}
+
+	return parsed;
+}
+
+function validateDirectory(directory: unknown): ValidationResult {
+	const errors: string[] = [];
+	const warnings: string[] = [];
+
+	if (directory === null || typeof directory !== "object") {
+		return { ok: false, errors: ["Directory must be a JSON object"], warnings };
+	}
+
+	const keys = getProperty(directory, "keys");
+	if (!Array.isArray(keys)) {
+		errors.push("Directory must include a keys array");
+	} else if (keys.length === 0) {
+		errors.push("Directory keys array must not be empty");
+	} else {
+		for (const [index, key] of keys.entries()) {
+			if (key === null || typeof key !== "object") {
+				errors.push(`keys[${index}] must be a JSON object`);
+				continue;
+			}
+
+			const kty = getStringProperty(key, "kty");
+			if (kty === undefined) {
+				errors.push(`keys[${index}].kty must be a string`);
+				continue;
+			}
+
+			if (kty !== "OKP") {
+				warnings.push(`keys[${index}].kty is not OKP`);
+				continue;
+			}
+
+			if (getStringProperty(key, "crv") !== "Ed25519") {
+				errors.push(`keys[${index}].crv must be Ed25519`);
+			}
+			const x = getStringProperty(key, "x");
+			if (x === undefined) {
+				errors.push(`keys[${index}].x must be a string`);
+			} else if (base64urlDecodedLength(x) !== 32) {
+				errors.push(`keys[${index}].x must be a 32-byte base64url value`);
+			}
+		}
+	}
+
+	const purpose = getProperty(directory, "purpose");
+	if (purpose !== undefined && typeof purpose !== "string") {
+		errors.push("Directory purpose must be a string when present");
+	}
+
+	return { ok: errors.length === 0, errors, warnings };
+}
+
+async function readTextWithLimit(
+	response: Response,
+	byteLimit: number
+): Promise<string> {
+	if (response.body === null) {
+		return "";
+	}
+
+	const reader = response.body.getReader();
+	const decoder = new TextDecoder();
+	let bytesRead = 0;
+	let text = "";
+
+	while (true) {
+		const result = await reader.read();
+		if (result.done) {
+			return text + decoder.decode();
+		}
+
+		bytesRead += result.value.byteLength;
+		if (bytesRead > byteLimit) {
+			await reader.cancel();
+			throw new Error("Directory response is too large");
+		}
+		text += decoder.decode(result.value, { stream: true });
+	}
+}
+
+async function validateDirectoryRequest(
+	request: Request,
+	env: Env
+): Promise<Response> {
+	if (request.method !== "POST") {
+		return errorResponse(["Method not allowed"], 405);
+	}
+	if (!hasExpectedRequestContext(request)) {
+		return errorResponse(["Bad request"]);
+	}
+
+	let body: unknown;
+	try {
+		body = await request.json();
+	} catch {
+		return errorResponse(["Request body must be valid JSON"]);
+	}
+
+	const url = getStringProperty(body, "url");
+	const turnstileToken = getStringProperty(body, "turnstileToken");
+	if (url === undefined || url.length === 0) {
+		return errorResponse(["Missing url"]);
+	}
+	if (turnstileToken === undefined || turnstileToken.length === 0) {
+		return errorResponse(["Missing Turnstile token"]);
+	}
+
+	const parsed = validateDirectoryURL(url);
+	if (parsed instanceof Response) {
+		return parsed;
+	}
+
+	const turnstileOK = await validateTurnstile(
+		env,
+		turnstileToken,
+		request.headers.get("CF-Connecting-IP")
+	);
+	if (!turnstileOK) {
+		return errorResponse(["Turnstile verification failed"], 403);
+	}
+
+	let response: Response;
+	try {
+		response = await fetch(parsed.toString(), {
+			redirect: "manual",
+			signal: AbortSignal.timeout(DIRECTORY_FETCH_TIMEOUT_MS),
+		});
+	} catch {
+		return errorResponse(["Directory fetch failed"], 502);
+	}
+
+	if (!response.ok) {
+		return errorResponse([`Directory returned HTTP ${response.status}`], 502);
+	}
+
+	const warnings: string[] = [];
+	const contentType = response.headers.get("Content-Type");
+	const mediaType = contentType?.split(";", 1)[0]?.trim().toLowerCase();
+	if (
+		mediaType !== MediaType.HTTP_MESSAGE_SIGNATURES_DIRECTORY &&
+		mediaType !== "application/json"
+	) {
+		warnings.push(
+			`Directory returned unexpected Content-Type ${contentType ?? "none"}`
+		);
+	}
+
+	let text: string;
+	try {
+		text = await readTextWithLimit(response, DIRECTORY_RESPONSE_MAX_BYTES);
+	} catch {
+		return errorResponse(["Directory response is too large"], 502);
+	}
+
+	let directory: unknown;
+	try {
+		directory = JSON.parse(text);
+	} catch {
+		return errorResponse(["Directory response must be valid JSON"], 502);
+	}
+
+	const result = validateDirectory(directory);
+	return validationResponse({
+		...result,
+		warnings: [...warnings, ...result.warnings],
+	});
+}
+
 async function getSigner(): Promise<Signer> {
 	return Ed25519Signer.fromJWK(jwk);
 }
@@ -99,6 +413,7 @@ function verifyEd25519(
 	params: VerificationParams
 ) => Promise<void> {
 	return async (data, signature, _params) => {
+		void _params;
 		const key = await crypto.subtle.importKey(
 			"jwk",
 			directory.keys[0],
@@ -146,13 +461,13 @@ async function verifySignature(
 			directory = await getExampleDirectory();
 		}
 	} catch (e) {
-		return SignatureValidationStatus.INVALID((e as Error).message);
+		return SignatureValidationStatus.INVALID(errorMessage(e));
 	}
 
 	try {
 		await verify(request, verifyEd25519(directory));
 	} catch (e) {
-		return SignatureValidationStatus.INVALID((e as Error).message);
+		return SignatureValidationStatus.INVALID(errorMessage(e));
 	}
 
 	console.log("Signature verified successfully");
@@ -165,6 +480,7 @@ async function verifySignature(
 
 export default {
 	async fetch(request, env, ctx): Promise<Response> {
+		void ctx;
 		const url = new URL(request.url);
 
 		if (url.pathname.startsWith("/debug")) {
@@ -178,6 +494,10 @@ export default {
 		if (url.pathname.startsWith("/v0/api/verify")) {
 			const status = await verifySignature(env, request);
 			return new Response(status);
+		}
+
+		if (url.pathname === "/v0/api/validate-directory") {
+			return validateDirectoryRequest(request, env);
 		}
 
 		if (url.pathname.startsWith(HTTP_MESSAGE_SIGNATURES_DIRECTORY)) {
@@ -197,23 +517,25 @@ export default {
 		}
 
 		const status = await verifySignature(env, request);
+		const turnstileSiteKey = getTurnstileSiteKey(env);
 		switch (status) {
 			case SignatureValidationStatus.NEUTRAL:
-				return new Response(neutralHTML, {
+				return new Response(generateHTML(undefined, turnstileSiteKey), {
 					headers: { "content-type": "text/html; charset=utf-8" },
 				});
 			case SignatureValidationStatus.VALID:
-				return new Response(validHTML, {
+				return new Response(generateHTML(true, turnstileSiteKey), {
 					headers: { "content-type": "text/html; charset=utf-8" },
 				});
 			default:
-				return new Response(invalidHTML, {
+				return new Response(generateHTML(false, turnstileSiteKey), {
 					headers: { "content-type": "text/html; charset=utf-8" },
 				});
 		}
 	},
 	// On a schedule, send a web-bot-auth signed request to a target endpoint
 	async scheduled(ctx, env, ectx) {
+		void ectx;
 		const headers = { "Signature-Agent": JSON.stringify(env.SIGNATURE_AGENT) };
 		const request = new Request(env.TARGET_URL, { headers });
 		const created = new Date(ctx.scheduledTime);

--- a/examples/verification-workers/src/index.ts
+++ b/examples/verification-workers/src/index.ts
@@ -37,6 +37,7 @@ interface ValidationResult {
 	ok: boolean;
 	errors: string[];
 	warnings: string[];
+	directory?: unknown;
 }
 
 function errorMessage(error: unknown): string {
@@ -60,11 +61,6 @@ function getStringProperty(value: unknown, name: string): string | undefined {
 	return typeof property === "string" ? property : undefined;
 }
 
-function getBooleanProperty(value: unknown, name: string): boolean | undefined {
-	const property = getProperty(value, name);
-	return typeof property === "boolean" ? property : undefined;
-}
-
 function validationResponse(result: ValidationResult, status = 200): Response {
 	return Response.json(result, { status });
 }
@@ -77,17 +73,12 @@ function getTurnstileSiteKey(env: Env): string {
 	return getStringProperty(env, "TURNSTILE_SITE_KEY") ?? "";
 }
 
-function base64urlDecodedLength(value: string): number | undefined {
-	if (!/^[A-Za-z0-9_-]+$/.test(value)) {
-		return undefined;
-	}
-	try {
-		const padding = "=".repeat((4 - (value.length % 4)) % 4);
-		return atob(value.replaceAll("-", "+").replaceAll("_", "/") + padding)
-			.length;
-	} catch {
-		return undefined;
-	}
+function getStringFormValue(
+	formData: FormData,
+	name: string
+): string | undefined {
+	const value = formData.get(name);
+	return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
 async function getExampleDirectory(): Promise<Directory> {
@@ -177,35 +168,10 @@ async function validateTurnstile(
 
 	try {
 		const body: unknown = await response.json();
-		return getBooleanProperty(body, "success") === true;
+		return getProperty(body, "success") === true;
 	} catch {
 		return false;
 	}
-}
-
-function hasExpectedRequestContext(request: Request): boolean {
-	const requestOrigin = new URL(request.url).origin;
-	if (request.headers.get("Origin") !== requestOrigin) {
-		return false;
-	}
-
-	const referer = request.headers.get("Referer");
-	if (referer === null) {
-		return false;
-	}
-	try {
-		if (new URL(referer).origin !== requestOrigin) {
-			return false;
-		}
-	} catch {
-		return false;
-	}
-
-	return (
-		request.headers.get("Sec-Fetch-Site") === "same-origin" &&
-		request.headers.get("Sec-Fetch-Mode") === "cors" &&
-		request.headers.get("Sec-Fetch-Dest") === "empty"
-	);
 }
 
 function validateDirectoryURL(url: string): URL | Response {
@@ -234,7 +200,7 @@ function validateDirectoryURL(url: string): URL | Response {
 	return parsed;
 }
 
-function validateDirectory(directory: unknown): ValidationResult {
+function validateDirectoryShape(directory: unknown): ValidationResult {
 	const errors: string[] = [];
 	const warnings: string[] = [];
 
@@ -251,28 +217,6 @@ function validateDirectory(directory: unknown): ValidationResult {
 		for (const [index, key] of keys.entries()) {
 			if (key === null || typeof key !== "object") {
 				errors.push(`keys[${index}] must be a JSON object`);
-				continue;
-			}
-
-			const kty = getStringProperty(key, "kty");
-			if (kty === undefined) {
-				errors.push(`keys[${index}].kty must be a string`);
-				continue;
-			}
-
-			if (kty !== "OKP") {
-				warnings.push(`keys[${index}].kty is not OKP`);
-				continue;
-			}
-
-			if (getStringProperty(key, "crv") !== "Ed25519") {
-				errors.push(`keys[${index}].crv must be Ed25519`);
-			}
-			const x = getStringProperty(key, "x");
-			if (x === undefined) {
-				errors.push(`keys[${index}].x must be a string`);
-			} else if (base64urlDecodedLength(x) !== 32) {
-				errors.push(`keys[${index}].x must be a 32-byte base64url value`);
 			}
 		}
 	}
@@ -282,7 +226,7 @@ function validateDirectory(directory: unknown): ValidationResult {
 		errors.push("Directory purpose must be a string when present");
 	}
 
-	return { ok: errors.length === 0, errors, warnings };
+	return { ok: errors.length === 0, errors, warnings, directory };
 }
 
 async function readTextWithLimit(
@@ -320,19 +264,16 @@ async function validateDirectoryRequest(
 	if (request.method !== "POST") {
 		return errorResponse(["Method not allowed"], 405);
 	}
-	if (!hasExpectedRequestContext(request)) {
-		return errorResponse(["Bad request"]);
-	}
 
-	let body: unknown;
+	let formData: FormData;
 	try {
-		body = await request.json();
+		formData = await request.formData();
 	} catch {
-		return errorResponse(["Request body must be valid JSON"]);
+		return errorResponse(["Request body must be form data"]);
 	}
 
-	const url = getStringProperty(body, "url");
-	const turnstileToken = getStringProperty(body, "turnstileToken");
+	const url = getStringFormValue(formData, "url");
+	const turnstileToken = getStringFormValue(formData, "cf-turnstile-response");
 	if (url === undefined || url.length === 0) {
 		return errorResponse(["Missing url"]);
 	}
@@ -394,7 +335,7 @@ async function validateDirectoryRequest(
 		return errorResponse(["Directory response must be valid JSON"], 502);
 	}
 
-	const result = validateDirectory(directory);
+	const result = validateDirectoryShape(directory);
 	return validationResponse({
 		...result,
 		warnings: [...warnings, ...result.warnings],

--- a/examples/verification-workers/src/index.ts
+++ b/examples/verification-workers/src/index.ts
@@ -24,7 +24,7 @@ import {
 	signatureHeaders,
 	verify,
 } from "web-bot-auth";
-import { generateHTML } from "./html";
+import { generateDebugHTML, generateHTML } from "./html";
 import jwk from "../../rfc9421-keys/ed25519.json" assert { type: "json" };
 import { Ed25519Signer } from "web-bot-auth/crypto";
 
@@ -371,11 +371,9 @@ export default {
 		const url = new URL(request.url);
 
 		if (url.pathname.startsWith("/debug")) {
-			return new Response(
-				[...request.headers]
-					.map(([key, value]) => `${key}: ${value}`)
-					.join("\n")
-			);
+			return new Response(generateDebugHTML(getTurnstileSiteKey(env)), {
+				headers: { "content-type": "text/html; charset=utf-8" },
+			});
 		}
 
 		if (url.pathname.startsWith("/v0/api/verify")) {
@@ -404,18 +402,17 @@ export default {
 		}
 
 		const status = await verifySignature(env, request);
-		const turnstileSiteKey = getTurnstileSiteKey(env);
 		switch (status) {
 			case SignatureValidationStatus.NEUTRAL:
-				return new Response(generateHTML(undefined, turnstileSiteKey), {
+				return new Response(generateHTML(undefined), {
 					headers: { "content-type": "text/html; charset=utf-8" },
 				});
 			case SignatureValidationStatus.VALID:
-				return new Response(generateHTML(true, turnstileSiteKey), {
+				return new Response(generateHTML(true), {
 					headers: { "content-type": "text/html; charset=utf-8" },
 				});
 			default:
-				return new Response(generateHTML(false, turnstileSiteKey), {
+				return new Response(generateHTML(false), {
 					headers: { "content-type": "text/html; charset=utf-8" },
 				});
 		}

--- a/examples/verification-workers/src/index.ts
+++ b/examples/verification-workers/src/index.ts
@@ -25,13 +25,9 @@ import {
 	verify,
 } from "web-bot-auth";
 import { generateDebugHTML, generateHTML } from "./html";
+import { proxyDirectoryRequest } from "./proxy-directory";
 import jwk from "../../rfc9421-keys/ed25519.json" assert { type: "json" };
 import { Ed25519Signer } from "web-bot-auth/crypto";
-
-const DIRECTORY_FETCH_TIMEOUT_MS = 5_000;
-const DIRECTORY_RESPONSE_MAX_BYTES = 64_000;
-const TURNSTILE_VERIFY_URL =
-	"https://challenges.cloudflare.com/turnstile/v0/siteverify";
 
 function errorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
@@ -54,20 +50,8 @@ function getStringProperty(value: unknown, name: string): string | undefined {
 	return typeof property === "string" ? property : undefined;
 }
 
-function errorResponse(error: string, status = 400): Response {
-	return Response.json({ error }, { status });
-}
-
 function getTurnstileSiteKey(env: Env): string {
 	return getStringProperty(env, "TURNSTILE_SITE_KEY") ?? "";
-}
-
-function getStringFormValue(
-	formData: FormData,
-	name: string
-): string | undefined {
-	const value = formData.get(name);
-	return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
 async function getExampleDirectory(): Promise<Directory> {
@@ -127,165 +111,6 @@ async function fetchDirectory(signatureAgent: string): Promise<Directory> {
 	);
 	const response = await fetch(`${parsed}${HTTP_MESSAGE_SIGNATURES_DIRECTORY}`);
 	return response.json();
-}
-
-async function validateTurnstile(
-	env: Env,
-	token: string,
-	remoteIP: string | null
-): Promise<boolean> {
-	const formData = new FormData();
-	formData.append("secret", env.TURNSTILE_SECRET_KEY);
-	formData.append("response", token);
-	if (remoteIP !== null) {
-		formData.append("remoteip", remoteIP);
-	}
-
-	let response: Response;
-	try {
-		response = await fetch(TURNSTILE_VERIFY_URL, {
-			body: formData,
-			method: "POST",
-		});
-	} catch {
-		return false;
-	}
-
-	if (!response.ok) {
-		return false;
-	}
-
-	try {
-		const body: unknown = await response.json();
-		return getProperty(body, "success") === true;
-	} catch {
-		return false;
-	}
-}
-
-function validateDirectoryURL(url: string): URL | string {
-	let parsed: URL;
-	try {
-		parsed = new URL(url);
-	} catch {
-		return "URL must be valid";
-	}
-
-	if (parsed.protocol !== "https:") {
-		return 'Directory URL must use "https:"';
-	}
-	if (parsed.username !== "" || parsed.password !== "") {
-		return "Directory URL must not include credentials";
-	}
-	if (parsed.port !== "") {
-		return "Directory URL must not use a custom port";
-	}
-	if (parsed.pathname !== HTTP_MESSAGE_SIGNATURES_DIRECTORY) {
-		return `Directory URL path must be ${HTTP_MESSAGE_SIGNATURES_DIRECTORY}`;
-	}
-
-	return parsed;
-}
-
-async function readTextWithLimit(
-	response: Response,
-	byteLimit: number
-): Promise<string> {
-	if (response.body === null) {
-		return "";
-	}
-
-	const reader = response.body.getReader();
-	const decoder = new TextDecoder();
-	let bytesRead = 0;
-	let text = "";
-
-	while (true) {
-		const result = await reader.read();
-		if (result.done) {
-			return text + decoder.decode();
-		}
-
-		bytesRead += result.value.byteLength;
-		if (bytesRead > byteLimit) {
-			await reader.cancel();
-			throw new Error("Directory response is too large");
-		}
-		text += decoder.decode(result.value, { stream: true });
-	}
-}
-
-async function proxyDirectoryRequest(
-	request: Request,
-	env: Env
-): Promise<Response> {
-	if (request.method !== "POST") {
-		return errorResponse("Method not allowed", 405);
-	}
-
-	const origin = request.headers.get("Origin");
-	if (origin !== new URL(request.url).origin) {
-		return errorResponse("Bad request");
-	}
-
-	let formData: FormData;
-	try {
-		formData = await request.formData();
-	} catch {
-		return errorResponse("Request body must be form data");
-	}
-
-	const url = getStringFormValue(formData, "url");
-	const turnstileToken = getStringFormValue(formData, "cf-turnstile-response");
-	if (url === undefined || url.length === 0) {
-		return errorResponse("Missing url");
-	}
-	if (turnstileToken === undefined || turnstileToken.length === 0) {
-		return errorResponse("Missing Turnstile token");
-	}
-
-	const parsed = validateDirectoryURL(url);
-	if (typeof parsed === "string") {
-		return errorResponse(parsed);
-	}
-
-	const turnstileOK = await validateTurnstile(
-		env,
-		turnstileToken,
-		request.headers.get("CF-Connecting-IP")
-	);
-	if (!turnstileOK) {
-		return errorResponse("Turnstile verification failed", 403);
-	}
-
-	let response: Response;
-	try {
-		response = await fetch(parsed.toString(), {
-			redirect: "manual",
-			signal: AbortSignal.timeout(DIRECTORY_FETCH_TIMEOUT_MS),
-		});
-	} catch {
-		return errorResponse("Directory fetch failed", 502);
-	}
-
-	if (!response.ok) {
-		return errorResponse(`Directory returned HTTP ${response.status}`, 502);
-	}
-
-	let text: string;
-	try {
-		text = await readTextWithLimit(response, DIRECTORY_RESPONSE_MAX_BYTES);
-	} catch {
-		return errorResponse("Directory response is too large", 502);
-	}
-
-	return new Response(text, {
-		headers: {
-			"Access-Control-Allow-Origin": origin,
-			"Content-Type":
-				response.headers.get("Content-Type") ?? "application/json",
-		},
-	});
 }
 
 async function getSigner(): Promise<Signer> {

--- a/examples/verification-workers/src/index.ts
+++ b/examples/verification-workers/src/index.ts
@@ -24,34 +24,14 @@ import {
 	signatureHeaders,
 	verify,
 } from "web-bot-auth";
-import { generateDebugHTML, generateHTML } from "./html";
+import { generateDebugHTML } from "./debug-html";
+import { invalidHTML, neutralHTML, validHTML } from "./index-html";
 import { proxyDirectoryRequest } from "./proxy-directory";
 import jwk from "../../rfc9421-keys/ed25519.json" assert { type: "json" };
 import { Ed25519Signer } from "web-bot-auth/crypto";
 
 function errorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
-}
-
-function getProperty(value: unknown, name: string): unknown {
-	if (value === null || typeof value !== "object") {
-		return undefined;
-	}
-	for (const [key, property] of Object.entries(value)) {
-		if (key === name) {
-			return property;
-		}
-	}
-	return undefined;
-}
-
-function getStringProperty(value: unknown, name: string): string | undefined {
-	const property = getProperty(value, name);
-	return typeof property === "string" ? property : undefined;
-}
-
-function getTurnstileSiteKey(env: Env): string {
-	return getStringProperty(env, "TURNSTILE_SITE_KEY") ?? "";
 }
 
 async function getExampleDirectory(): Promise<Directory> {
@@ -196,7 +176,7 @@ export default {
 		const url = new URL(request.url);
 
 		if (url.pathname.startsWith("/debug")) {
-			return new Response(generateDebugHTML(getTurnstileSiteKey(env)), {
+			return new Response(generateDebugHTML(env.TURNSTILE_SITE_KEY ?? ""), {
 				headers: { "content-type": "text/html; charset=utf-8" },
 			});
 		}
@@ -229,15 +209,15 @@ export default {
 		const status = await verifySignature(env, request);
 		switch (status) {
 			case SignatureValidationStatus.NEUTRAL:
-				return new Response(generateHTML(undefined), {
+				return new Response(neutralHTML, {
 					headers: { "content-type": "text/html; charset=utf-8" },
 				});
 			case SignatureValidationStatus.VALID:
-				return new Response(generateHTML(true), {
+				return new Response(validHTML, {
 					headers: { "content-type": "text/html; charset=utf-8" },
 				});
 			default:
-				return new Response(generateHTML(false), {
+				return new Response(invalidHTML, {
 					headers: { "content-type": "text/html; charset=utf-8" },
 				});
 		}

--- a/examples/verification-workers/src/index.ts
+++ b/examples/verification-workers/src/index.ts
@@ -33,13 +33,6 @@ const DIRECTORY_RESPONSE_MAX_BYTES = 64_000;
 const TURNSTILE_VERIFY_URL =
 	"https://challenges.cloudflare.com/turnstile/v0/siteverify";
 
-interface ValidationResult {
-	ok: boolean;
-	errors: string[];
-	warnings: string[];
-	directory?: unknown;
-}
-
 function errorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
 }
@@ -61,12 +54,8 @@ function getStringProperty(value: unknown, name: string): string | undefined {
 	return typeof property === "string" ? property : undefined;
 }
 
-function validationResponse(result: ValidationResult, status = 200): Response {
-	return Response.json(result, { status });
-}
-
-function errorResponse(errors: string[], status = 400): Response {
-	return validationResponse({ ok: false, errors, warnings: [] }, status);
+function errorResponse(error: string, status = 400): Response {
+	return Response.json({ error }, { status });
 }
 
 function getTurnstileSiteKey(env: Env): string {
@@ -174,59 +163,28 @@ async function validateTurnstile(
 	}
 }
 
-function validateDirectoryURL(url: string): URL | Response {
+function validateDirectoryURL(url: string): URL | string {
 	let parsed: URL;
 	try {
 		parsed = new URL(url);
 	} catch {
-		return errorResponse(["URL must be valid"]);
+		return "URL must be valid";
 	}
 
 	if (parsed.protocol !== "https:") {
-		return errorResponse(['Directory URL must use "https:"']);
+		return 'Directory URL must use "https:"';
 	}
 	if (parsed.username !== "" || parsed.password !== "") {
-		return errorResponse(["Directory URL must not include credentials"]);
+		return "Directory URL must not include credentials";
 	}
 	if (parsed.port !== "") {
-		return errorResponse(["Directory URL must not use a custom port"]);
+		return "Directory URL must not use a custom port";
 	}
 	if (parsed.pathname !== HTTP_MESSAGE_SIGNATURES_DIRECTORY) {
-		return errorResponse([
-			`Directory URL path must be ${HTTP_MESSAGE_SIGNATURES_DIRECTORY}`,
-		]);
+		return `Directory URL path must be ${HTTP_MESSAGE_SIGNATURES_DIRECTORY}`;
 	}
 
 	return parsed;
-}
-
-function validateDirectoryShape(directory: unknown): ValidationResult {
-	const errors: string[] = [];
-	const warnings: string[] = [];
-
-	if (directory === null || typeof directory !== "object") {
-		return { ok: false, errors: ["Directory must be a JSON object"], warnings };
-	}
-
-	const keys = getProperty(directory, "keys");
-	if (!Array.isArray(keys)) {
-		errors.push("Directory must include a keys array");
-	} else if (keys.length === 0) {
-		errors.push("Directory keys array must not be empty");
-	} else {
-		for (const [index, key] of keys.entries()) {
-			if (key === null || typeof key !== "object") {
-				errors.push(`keys[${index}] must be a JSON object`);
-			}
-		}
-	}
-
-	const purpose = getProperty(directory, "purpose");
-	if (purpose !== undefined && typeof purpose !== "string") {
-		errors.push("Directory purpose must be a string when present");
-	}
-
-	return { ok: errors.length === 0, errors, warnings, directory };
 }
 
 async function readTextWithLimit(
@@ -257,33 +215,38 @@ async function readTextWithLimit(
 	}
 }
 
-async function validateDirectoryRequest(
+async function proxyDirectoryRequest(
 	request: Request,
 	env: Env
 ): Promise<Response> {
 	if (request.method !== "POST") {
-		return errorResponse(["Method not allowed"], 405);
+		return errorResponse("Method not allowed", 405);
+	}
+
+	const origin = request.headers.get("Origin");
+	if (origin !== new URL(request.url).origin) {
+		return errorResponse("Bad request");
 	}
 
 	let formData: FormData;
 	try {
 		formData = await request.formData();
 	} catch {
-		return errorResponse(["Request body must be form data"]);
+		return errorResponse("Request body must be form data");
 	}
 
 	const url = getStringFormValue(formData, "url");
 	const turnstileToken = getStringFormValue(formData, "cf-turnstile-response");
 	if (url === undefined || url.length === 0) {
-		return errorResponse(["Missing url"]);
+		return errorResponse("Missing url");
 	}
 	if (turnstileToken === undefined || turnstileToken.length === 0) {
-		return errorResponse(["Missing Turnstile token"]);
+		return errorResponse("Missing Turnstile token");
 	}
 
 	const parsed = validateDirectoryURL(url);
-	if (parsed instanceof Response) {
-		return parsed;
+	if (typeof parsed === "string") {
+		return errorResponse(parsed);
 	}
 
 	const turnstileOK = await validateTurnstile(
@@ -292,7 +255,7 @@ async function validateDirectoryRequest(
 		request.headers.get("CF-Connecting-IP")
 	);
 	if (!turnstileOK) {
-		return errorResponse(["Turnstile verification failed"], 403);
+		return errorResponse("Turnstile verification failed", 403);
 	}
 
 	let response: Response;
@@ -302,43 +265,26 @@ async function validateDirectoryRequest(
 			signal: AbortSignal.timeout(DIRECTORY_FETCH_TIMEOUT_MS),
 		});
 	} catch {
-		return errorResponse(["Directory fetch failed"], 502);
+		return errorResponse("Directory fetch failed", 502);
 	}
 
 	if (!response.ok) {
-		return errorResponse([`Directory returned HTTP ${response.status}`], 502);
-	}
-
-	const warnings: string[] = [];
-	const contentType = response.headers.get("Content-Type");
-	const mediaType = contentType?.split(";", 1)[0]?.trim().toLowerCase();
-	if (
-		mediaType !== MediaType.HTTP_MESSAGE_SIGNATURES_DIRECTORY &&
-		mediaType !== "application/json"
-	) {
-		warnings.push(
-			`Directory returned unexpected Content-Type ${contentType ?? "none"}`
-		);
+		return errorResponse(`Directory returned HTTP ${response.status}`, 502);
 	}
 
 	let text: string;
 	try {
 		text = await readTextWithLimit(response, DIRECTORY_RESPONSE_MAX_BYTES);
 	} catch {
-		return errorResponse(["Directory response is too large"], 502);
+		return errorResponse("Directory response is too large", 502);
 	}
 
-	let directory: unknown;
-	try {
-		directory = JSON.parse(text);
-	} catch {
-		return errorResponse(["Directory response must be valid JSON"], 502);
-	}
-
-	const result = validateDirectoryShape(directory);
-	return validationResponse({
-		...result,
-		warnings: [...warnings, ...result.warnings],
+	return new Response(text, {
+		headers: {
+			"Access-Control-Allow-Origin": origin,
+			"Content-Type":
+				response.headers.get("Content-Type") ?? "application/json",
+		},
 	});
 }
 
@@ -437,8 +383,8 @@ export default {
 			return new Response(status);
 		}
 
-		if (url.pathname === "/v0/api/validate-directory") {
-			return validateDirectoryRequest(request, env);
+		if (url.pathname === "/v0/api/proxy-directory") {
+			return proxyDirectoryRequest(request, env);
 		}
 
 		if (url.pathname.startsWith(HTTP_MESSAGE_SIGNATURES_DIRECTORY)) {

--- a/examples/verification-workers/src/proxy-directory.ts
+++ b/examples/verification-workers/src/proxy-directory.ts
@@ -1,0 +1,203 @@
+// Copyright 2025 Cloudflare, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { HTTP_MESSAGE_SIGNATURES_DIRECTORY } from "web-bot-auth";
+
+const DIRECTORY_FETCH_TIMEOUT_MS = 5_000;
+const DIRECTORY_RESPONSE_MAX_BYTES = 64_000;
+const TURNSTILE_VERIFY_URL =
+	"https://challenges.cloudflare.com/turnstile/v0/siteverify";
+
+function getProperty(value: unknown, name: string): unknown {
+	if (value === null || typeof value !== "object") {
+		return undefined;
+	}
+	for (const [key, property] of Object.entries(value)) {
+		if (key === name) {
+			return property;
+		}
+	}
+	return undefined;
+}
+
+function errorResponse(error: string, status = 400): Response {
+	return Response.json({ error }, { status });
+}
+
+function getStringFormValue(
+	formData: FormData,
+	name: string
+): string | undefined {
+	const value = formData.get(name);
+	return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+async function validateTurnstile(
+	env: Env,
+	token: string,
+	remoteIP: string | null
+): Promise<boolean> {
+	const formData = new FormData();
+	formData.append("secret", env.TURNSTILE_SECRET_KEY);
+	formData.append("response", token);
+	if (remoteIP !== null) {
+		formData.append("remoteip", remoteIP);
+	}
+
+	let response: Response;
+	try {
+		response = await fetch(TURNSTILE_VERIFY_URL, {
+			body: formData,
+			method: "POST",
+		});
+	} catch {
+		return false;
+	}
+
+	if (!response.ok) {
+		return false;
+	}
+
+	try {
+		const body: unknown = await response.json();
+		return getProperty(body, "success") === true;
+	} catch {
+		return false;
+	}
+}
+
+function validateDirectoryURL(url: string): URL | string {
+	let parsed: URL;
+	try {
+		parsed = new URL(url);
+	} catch {
+		return "URL must be valid";
+	}
+
+	if (parsed.protocol !== "https:") {
+		return 'Directory URL must use "https:"';
+	}
+	if (parsed.username !== "" || parsed.password !== "") {
+		return "Directory URL must not include credentials";
+	}
+	if (parsed.port !== "") {
+		return "Directory URL must not use a custom port";
+	}
+	if (parsed.pathname !== HTTP_MESSAGE_SIGNATURES_DIRECTORY) {
+		return `Directory URL path must be ${HTTP_MESSAGE_SIGNATURES_DIRECTORY}`;
+	}
+
+	return parsed;
+}
+
+async function readTextWithLimit(
+	response: Response,
+	byteLimit: number
+): Promise<string> {
+	if (response.body === null) {
+		return "";
+	}
+
+	const reader = response.body.getReader();
+	const decoder = new TextDecoder();
+	let bytesRead = 0;
+	let text = "";
+
+	while (true) {
+		const result = await reader.read();
+		if (result.done) {
+			return text + decoder.decode();
+		}
+
+		bytesRead += result.value.byteLength;
+		if (bytesRead > byteLimit) {
+			await reader.cancel();
+			throw new Error("Directory response is too large");
+		}
+		text += decoder.decode(result.value, { stream: true });
+	}
+}
+
+export async function proxyDirectoryRequest(
+	request: Request,
+	env: Env
+): Promise<Response> {
+	if (request.method !== "POST") {
+		return errorResponse("Method not allowed", 405);
+	}
+
+	const origin = request.headers.get("Origin");
+	if (origin !== new URL(request.url).origin) {
+		return errorResponse("Bad request");
+	}
+
+	let formData: FormData;
+	try {
+		formData = await request.formData();
+	} catch {
+		return errorResponse("Request body must be form data");
+	}
+
+	const url = getStringFormValue(formData, "url");
+	const turnstileToken = getStringFormValue(formData, "cf-turnstile-response");
+	if (url === undefined || url.length === 0) {
+		return errorResponse("Missing url");
+	}
+	if (turnstileToken === undefined || turnstileToken.length === 0) {
+		return errorResponse("Missing Turnstile token");
+	}
+
+	const parsed = validateDirectoryURL(url);
+	if (typeof parsed === "string") {
+		return errorResponse(parsed);
+	}
+
+	const turnstileOK = await validateTurnstile(
+		env,
+		turnstileToken,
+		request.headers.get("CF-Connecting-IP")
+	);
+	if (!turnstileOK) {
+		return errorResponse("Turnstile verification failed", 403);
+	}
+
+	let response: Response;
+	try {
+		response = await fetch(parsed.toString(), {
+			redirect: "manual",
+			signal: AbortSignal.timeout(DIRECTORY_FETCH_TIMEOUT_MS),
+		});
+	} catch {
+		return errorResponse("Directory fetch failed", 502);
+	}
+
+	if (!response.ok) {
+		return errorResponse(`Directory returned HTTP ${response.status}`, 502);
+	}
+
+	let text: string;
+	try {
+		text = await readTextWithLimit(response, DIRECTORY_RESPONSE_MAX_BYTES);
+	} catch {
+		return errorResponse("Directory response is too large", 502);
+	}
+
+	return new Response(text, {
+		headers: {
+			"Access-Control-Allow-Origin": origin,
+			"Content-Type":
+				response.headers.get("Content-Type") ?? "application/json",
+		},
+	});
+}

--- a/examples/verification-workers/src/proxy-directory.ts
+++ b/examples/verification-workers/src/proxy-directory.ts
@@ -94,8 +94,8 @@ function validateDirectoryURL(url: string): URL | string {
 	if (parsed.port !== "") {
 		return "Directory URL must not use a custom port";
 	}
-	if (parsed.pathname !== HTTP_MESSAGE_SIGNATURES_DIRECTORY) {
-		return `Directory URL path must be ${HTTP_MESSAGE_SIGNATURES_DIRECTORY}`;
+	if (!parsed.pathname.endsWith(HTTP_MESSAGE_SIGNATURES_DIRECTORY)) {
+		return `Directory URL path must end with ${HTTP_MESSAGE_SIGNATURES_DIRECTORY}`;
 	}
 
 	return parsed;

--- a/examples/verification-workers/test/index.spec.ts
+++ b/examples/verification-workers/test/index.spec.ts
@@ -27,13 +27,14 @@ import worker from "../src/index";
 const IncomingRequest = Request<unknown, IncomingRequestCfProperties>;
 
 const sampleURL = "https://example.com";
-const validatorURL = `${sampleURL}/v0/api/validate-directory`;
+const proxyURL = `${sampleURL}/v0/api/proxy-directory`;
 const directoryURL = `${sampleURL}/.well-known/http-message-signatures-directory`;
 const turnstileVerifyURL =
 	"https://challenges.cloudflare.com/turnstile/v0/siteverify";
 
 const validatorHeaders = {
 	"CF-Connecting-IP": "192.0.2.1",
+	Origin: sampleURL,
 };
 
 function validatorRequest(body: Record<string, string>): Request {
@@ -41,7 +42,7 @@ function validatorRequest(body: Record<string, string>): Request {
 	for (const [name, value] of Object.entries(body)) {
 		formData.append(name, value);
 	}
-	return new IncomingRequest(validatorURL, {
+	return new IncomingRequest(proxyURL, {
 		body: formData,
 		headers: validatorHeaders,
 		method: "POST",
@@ -92,9 +93,9 @@ describe("/debug endpoint", () => {
 	});
 });
 
-describe("/v0/api/validate-directory endpoint", () => {
+describe("/v0/api/proxy-directory endpoint", () => {
 	it("rejects non-POST requests", async () => {
-		const request = new IncomingRequest(validatorURL, {
+		const request = new IncomingRequest(proxyURL, {
 			headers: validatorHeaders,
 		});
 		const ctx = createExecutionContext();
@@ -103,10 +104,25 @@ describe("/v0/api/validate-directory endpoint", () => {
 
 		expect(response.status).toEqual(405);
 		expect(await response.json()).toEqual({
-			ok: false,
-			errors: ["Method not allowed"],
-			warnings: [],
+			error: "Method not allowed",
 		});
+	});
+
+	it("requires same-origin requests", async () => {
+		const fetch = vi.fn();
+		vi.stubGlobal("fetch", fetch);
+		const request = validatorRequest({
+			url: directoryURL,
+			"cf-turnstile-response": "token",
+		});
+		request.headers.set("Origin", "https://attacker.example");
+		const ctx = createExecutionContext();
+		const response = await worker.fetch(request, env, ctx);
+		await waitOnExecutionContext(ctx);
+
+		expect(response.status).toEqual(400);
+		expect(fetch).not.toHaveBeenCalled();
+		expect(await response.json()).toEqual({ error: "Bad request" });
 	});
 
 	it("requires a Turnstile token", async () => {
@@ -114,9 +130,7 @@ describe("/v0/api/validate-directory endpoint", () => {
 
 		expect(response.status).toEqual(400);
 		expect(await response.json()).toEqual({
-			ok: false,
-			errors: ["Missing Turnstile token"],
-			warnings: [],
+			error: "Missing Turnstile token",
 		});
 	});
 
@@ -133,9 +147,7 @@ describe("/v0/api/validate-directory endpoint", () => {
 
 		expect(response.status).toEqual(403);
 		expect(await response.json()).toEqual({
-			ok: false,
-			errors: ["Turnstile verification failed"],
-			warnings: [],
+			error: "Turnstile verification failed",
 		});
 	});
 
@@ -151,9 +163,7 @@ describe("/v0/api/validate-directory endpoint", () => {
 		expect(response.status).toEqual(400);
 		expect(fetch).not.toHaveBeenCalled();
 		expect(await response.json()).toEqual({
-			ok: false,
-			errors: ["Directory URL must not use a custom port"],
-			warnings: [],
+			error: "Directory URL must not use a custom port",
 		});
 	});
 
@@ -176,9 +186,7 @@ describe("/v0/api/validate-directory endpoint", () => {
 
 		expect(response.status).toEqual(502);
 		expect(await response.json()).toEqual({
-			ok: false,
-			errors: ["Directory fetch failed"],
-			warnings: [],
+			error: "Directory fetch failed",
 		});
 	});
 
@@ -202,9 +210,7 @@ describe("/v0/api/validate-directory endpoint", () => {
 			signal: expect.any(AbortSignal),
 		});
 		expect(await response.json()).toEqual({
-			ok: false,
-			errors: ["Directory returned HTTP 302"],
-			warnings: [],
+			error: "Directory returned HTTP 302",
 		});
 	});
 
@@ -218,13 +224,11 @@ describe("/v0/api/validate-directory endpoint", () => {
 
 		expect(response.status).toEqual(502);
 		expect(await response.json()).toEqual({
-			ok: false,
-			errors: ["Directory response is too large"],
-			warnings: [],
+			error: "Directory response is too large",
 		});
 	});
 
-	it("validates a directory and warns on loose content type", async () => {
+	it("proxies a directory response", async () => {
 		const directory = {
 			keys: [{}],
 			purpose: "",
@@ -244,11 +248,10 @@ describe("/v0/api/validate-directory endpoint", () => {
 		});
 
 		expect(response.status).toEqual(200);
-		expect(await response.json()).toEqual({
-			ok: true,
-			errors: [],
-			directory,
-			warnings: ["Directory returned unexpected Content-Type text/plain"],
-		});
+		expect(response.headers.get("Access-Control-Allow-Origin")).toEqual(
+			sampleURL
+		);
+		expect(response.headers.get("Content-Type")).toEqual("text/plain");
+		expect(await response.json()).toEqual(directory);
 	});
 });

--- a/examples/verification-workers/test/index.spec.ts
+++ b/examples/verification-workers/test/index.spec.ts
@@ -79,17 +79,47 @@ describe("/ endpoint", () => {
 		await waitOnExecutionContext(ctx);
 		expect(response.status).toEqual(200);
 	});
+
+	it("does not render the directory validator", async () => {
+		const request = new IncomingRequest(sampleURL);
+		const ctx = createExecutionContext();
+		const response = await worker.fetch(request, env, ctx);
+		await waitOnExecutionContext(ctx);
+
+		expect(await response.text()).not.toContain("directory-validator");
+	});
 });
 
 describe("/debug endpoint", () => {
-	it("responds with request headers", async () => {
-		const headers = { test: "this is a test header" };
-		const request = new Request(`${sampleURL}/debug`, { headers });
+	it("responds with HTML", async () => {
+		const request = new Request(`${sampleURL}/debug`);
 		const response = await SELF.fetch(request);
-		const headersString = Object.entries(headers)
-			.map(([k, v]) => `${k}: ${v}`)
-			.join("\n");
-		expect(await response.text()).toMatch(headersString);
+
+		expect(response.status).toEqual(200);
+		expect(response.headers.get("content-type")).toContain("text/html");
+	});
+
+	it("renders directory validation tools", async () => {
+		const request = new Request(`${sampleURL}/debug`);
+		const response = await SELF.fetch(request);
+		const body = await response.text();
+
+		expect(body).toContain("directory-validator");
+		expect(body).toContain("Validate key directory");
+	});
+
+	it("renders signature header placeholders", async () => {
+		const request = new Request(`${sampleURL}/debug`);
+		const response = await SELF.fetch(request);
+		const body = await response.text();
+
+		expect(body).toContain("Verify request headers");
+		expect(body).toContain("Directory URL");
+		expect(body).toContain("Method");
+		expect(body).toContain("URL");
+		expect(body).toContain("Signature");
+		expect(body).toContain("Signature-Agent");
+		expect(body).toContain("Signature-Input");
 	});
 });
 

--- a/examples/verification-workers/test/index.spec.ts
+++ b/examples/verification-workers/test/index.spec.ts
@@ -19,7 +19,7 @@ import {
 	waitOnExecutionContext,
 	SELF,
 } from "cloudflare:test";
-import { describe, it, expect } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 import worker from "../src/index";
 
 // For now, you'll need to do something like this to get a correctly-typed
@@ -27,6 +27,51 @@ import worker from "../src/index";
 const IncomingRequest = Request<unknown, IncomingRequestCfProperties>;
 
 const sampleURL = "https://example.com";
+const validatorURL = `${sampleURL}/v0/api/validate-directory`;
+const directoryURL = `${sampleURL}/.well-known/http-message-signatures-directory`;
+const validEd25519X = "JrQLj5P_89iXES9-vFgrIy29clF9CC_oPPsw3c5D0bs";
+const turnstileVerifyURL =
+	"https://challenges.cloudflare.com/turnstile/v0/siteverify";
+
+const validatorHeaders = {
+	"CF-Connecting-IP": "192.0.2.1",
+	"Content-Type": "application/json",
+	Origin: sampleURL,
+	Referer: `${sampleURL}/`,
+	"Sec-Fetch-Dest": "empty",
+	"Sec-Fetch-Mode": "cors",
+	"Sec-Fetch-Site": "same-origin",
+};
+
+function validatorRequest(body: Record<string, string>): Request {
+	return new IncomingRequest(validatorURL, {
+		body: JSON.stringify(body),
+		headers: validatorHeaders,
+		method: "POST",
+	});
+}
+
+function mockedFetch(targetResponse: Response): ReturnType<typeof vi.fn> {
+	return vi.fn((input: RequestInfo | URL) => {
+		const url = input instanceof Request ? input.url : input.toString();
+		if (url === turnstileVerifyURL) {
+			return Promise.resolve(Response.json({ success: true }));
+		}
+		return Promise.resolve(targetResponse.clone());
+	});
+}
+
+async function fetchValidator(body: Record<string, string>): Promise<Response> {
+	const ctx = createExecutionContext();
+	const response = await worker.fetch(validatorRequest(body), env, ctx);
+	await waitOnExecutionContext(ctx);
+	return response;
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.restoreAllMocks();
+});
 
 describe("/ endpoint", () => {
 	it("responds with HTTP 200", async () => {
@@ -47,5 +92,234 @@ describe("/debug endpoint", () => {
 			.map(([k, v]) => `${k}: ${v}`)
 			.join("\n");
 		expect(await response.text()).toMatch(headersString);
+	});
+});
+
+describe("/v0/api/validate-directory endpoint", () => {
+	it("rejects non-POST requests", async () => {
+		const request = new IncomingRequest(validatorURL, {
+			headers: validatorHeaders,
+		});
+		const ctx = createExecutionContext();
+		const response = await worker.fetch(request, env, ctx);
+		await waitOnExecutionContext(ctx);
+
+		expect(response.status).toEqual(405);
+		expect(await response.json()).toEqual({
+			ok: false,
+			errors: ["Method not allowed"],
+			warnings: [],
+		});
+	});
+
+	it("requires same-origin browser context", async () => {
+		const fetch = vi.fn();
+		vi.stubGlobal("fetch", fetch);
+		const request = new IncomingRequest(validatorURL, {
+			body: JSON.stringify({ url: directoryURL, turnstileToken: "token" }),
+			headers: { ...validatorHeaders, Origin: "https://attacker.example" },
+			method: "POST",
+		});
+		const ctx = createExecutionContext();
+		const response = await worker.fetch(request, env, ctx);
+		await waitOnExecutionContext(ctx);
+
+		expect(response.status).toEqual(400);
+		expect(fetch).not.toHaveBeenCalled();
+		expect(await response.json()).toEqual({
+			ok: false,
+			errors: ["Bad request"],
+			warnings: [],
+		});
+	});
+
+	it("requires a Turnstile token", async () => {
+		const response = await fetchValidator({ url: directoryURL });
+
+		expect(response.status).toEqual(400);
+		expect(await response.json()).toEqual({
+			ok: false,
+			errors: ["Missing Turnstile token"],
+			warnings: [],
+		});
+	});
+
+	it("rejects failed Turnstile verification", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(() => Promise.resolve(Response.json({ success: false })))
+		);
+
+		const response = await fetchValidator({
+			url: directoryURL,
+			turnstileToken: "token",
+		});
+
+		expect(response.status).toEqual(403);
+		expect(await response.json()).toEqual({
+			ok: false,
+			errors: ["Turnstile verification failed"],
+			warnings: [],
+		});
+	});
+
+	it("rejects custom target ports", async () => {
+		const fetch = vi.fn();
+		vi.stubGlobal("fetch", fetch);
+
+		const response = await fetchValidator({
+			url: "https://example.com:8443/.well-known/http-message-signatures-directory",
+			turnstileToken: "token",
+		});
+
+		expect(response.status).toEqual(400);
+		expect(fetch).not.toHaveBeenCalled();
+		expect(await response.json()).toEqual({
+			ok: false,
+			errors: ["Directory URL must not use a custom port"],
+			warnings: [],
+		});
+	});
+
+	it("reports target fetch failures", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn((input: RequestInfo | URL) => {
+				const url = input instanceof Request ? input.url : input.toString();
+				if (url === turnstileVerifyURL) {
+					return Promise.resolve(Response.json({ success: true }));
+				}
+				return Promise.reject(new Error("network failed"));
+			})
+		);
+
+		const response = await fetchValidator({
+			url: directoryURL,
+			turnstileToken: "token",
+		});
+
+		expect(response.status).toEqual(502);
+		expect(await response.json()).toEqual({
+			ok: false,
+			errors: ["Directory fetch failed"],
+			warnings: [],
+		});
+	});
+
+	it("does not follow target redirects", async () => {
+		const fetch = mockedFetch(
+			new Response(null, {
+				headers: { Location: "https://example.com:8443/anything" },
+				status: 302,
+			})
+		);
+		vi.stubGlobal("fetch", fetch);
+
+		const response = await fetchValidator({
+			url: directoryURL,
+			turnstileToken: "token",
+		});
+
+		expect(response.status).toEqual(502);
+		expect(fetch).toHaveBeenLastCalledWith(directoryURL, {
+			redirect: "manual",
+			signal: expect.any(AbortSignal),
+		});
+		expect(await response.json()).toEqual({
+			ok: false,
+			errors: ["Directory returned HTTP 302"],
+			warnings: [],
+		});
+	});
+
+	it("rejects oversized directory responses", async () => {
+		vi.stubGlobal("fetch", mockedFetch(new Response("x".repeat(64_001))));
+
+		const response = await fetchValidator({
+			url: directoryURL,
+			turnstileToken: "token",
+		});
+
+		expect(response.status).toEqual(502);
+		expect(await response.json()).toEqual({
+			ok: false,
+			errors: ["Directory response is too large"],
+			warnings: [],
+		});
+	});
+
+	it("rejects unusable Ed25519 keys", async () => {
+		vi.stubGlobal(
+			"fetch",
+			mockedFetch(
+				Response.json({
+					keys: [{ crv: "Ed25519", kty: "OKP" }],
+					purpose: "",
+				})
+			)
+		);
+
+		const response = await fetchValidator({
+			url: directoryURL,
+			turnstileToken: "token",
+		});
+
+		expect(response.status).toEqual(200);
+		expect(await response.json()).toEqual({
+			ok: false,
+			errors: ["keys[0].x must be a string"],
+			warnings: [],
+		});
+	});
+
+	it("rejects malformed Ed25519 key material", async () => {
+		vi.stubGlobal(
+			"fetch",
+			mockedFetch(
+				Response.json({
+					keys: [{ crv: "Ed25519", kty: "OKP", x: "abc" }],
+					purpose: "",
+				})
+			)
+		);
+
+		const response = await fetchValidator({
+			url: directoryURL,
+			turnstileToken: "token",
+		});
+
+		expect(response.status).toEqual(200);
+		expect(await response.json()).toEqual({
+			ok: false,
+			errors: ["keys[0].x must be a 32-byte base64url value"],
+			warnings: [],
+		});
+	});
+
+	it("validates a directory and warns on loose content type", async () => {
+		vi.stubGlobal(
+			"fetch",
+			mockedFetch(
+				new Response(
+					JSON.stringify({
+						keys: [{ crv: "Ed25519", kty: "OKP", x: validEd25519X }],
+						purpose: "",
+					}),
+					{ headers: { "Content-Type": "text/plain" } }
+				)
+			)
+		);
+
+		const response = await fetchValidator({
+			url: directoryURL,
+			turnstileToken: "token",
+		});
+
+		expect(response.status).toEqual(200);
+		expect(await response.json()).toEqual({
+			ok: true,
+			errors: [],
+			warnings: ["Directory returned unexpected Content-Type text/plain"],
+		});
 	});
 });

--- a/examples/verification-workers/test/index.spec.ts
+++ b/examples/verification-workers/test/index.spec.ts
@@ -29,23 +29,20 @@ const IncomingRequest = Request<unknown, IncomingRequestCfProperties>;
 const sampleURL = "https://example.com";
 const validatorURL = `${sampleURL}/v0/api/validate-directory`;
 const directoryURL = `${sampleURL}/.well-known/http-message-signatures-directory`;
-const validEd25519X = "JrQLj5P_89iXES9-vFgrIy29clF9CC_oPPsw3c5D0bs";
 const turnstileVerifyURL =
 	"https://challenges.cloudflare.com/turnstile/v0/siteverify";
 
 const validatorHeaders = {
 	"CF-Connecting-IP": "192.0.2.1",
-	"Content-Type": "application/json",
-	Origin: sampleURL,
-	Referer: `${sampleURL}/`,
-	"Sec-Fetch-Dest": "empty",
-	"Sec-Fetch-Mode": "cors",
-	"Sec-Fetch-Site": "same-origin",
 };
 
 function validatorRequest(body: Record<string, string>): Request {
+	const formData = new FormData();
+	for (const [name, value] of Object.entries(body)) {
+		formData.append(name, value);
+	}
 	return new IncomingRequest(validatorURL, {
-		body: JSON.stringify(body),
+		body: formData,
 		headers: validatorHeaders,
 		method: "POST",
 	});
@@ -112,27 +109,6 @@ describe("/v0/api/validate-directory endpoint", () => {
 		});
 	});
 
-	it("requires same-origin browser context", async () => {
-		const fetch = vi.fn();
-		vi.stubGlobal("fetch", fetch);
-		const request = new IncomingRequest(validatorURL, {
-			body: JSON.stringify({ url: directoryURL, turnstileToken: "token" }),
-			headers: { ...validatorHeaders, Origin: "https://attacker.example" },
-			method: "POST",
-		});
-		const ctx = createExecutionContext();
-		const response = await worker.fetch(request, env, ctx);
-		await waitOnExecutionContext(ctx);
-
-		expect(response.status).toEqual(400);
-		expect(fetch).not.toHaveBeenCalled();
-		expect(await response.json()).toEqual({
-			ok: false,
-			errors: ["Bad request"],
-			warnings: [],
-		});
-	});
-
 	it("requires a Turnstile token", async () => {
 		const response = await fetchValidator({ url: directoryURL });
 
@@ -152,7 +128,7 @@ describe("/v0/api/validate-directory endpoint", () => {
 
 		const response = await fetchValidator({
 			url: directoryURL,
-			turnstileToken: "token",
+			"cf-turnstile-response": "token",
 		});
 
 		expect(response.status).toEqual(403);
@@ -169,7 +145,7 @@ describe("/v0/api/validate-directory endpoint", () => {
 
 		const response = await fetchValidator({
 			url: "https://example.com:8443/.well-known/http-message-signatures-directory",
-			turnstileToken: "token",
+			"cf-turnstile-response": "token",
 		});
 
 		expect(response.status).toEqual(400);
@@ -195,7 +171,7 @@ describe("/v0/api/validate-directory endpoint", () => {
 
 		const response = await fetchValidator({
 			url: directoryURL,
-			turnstileToken: "token",
+			"cf-turnstile-response": "token",
 		});
 
 		expect(response.status).toEqual(502);
@@ -217,7 +193,7 @@ describe("/v0/api/validate-directory endpoint", () => {
 
 		const response = await fetchValidator({
 			url: directoryURL,
-			turnstileToken: "token",
+			"cf-turnstile-response": "token",
 		});
 
 		expect(response.status).toEqual(502);
@@ -237,7 +213,7 @@ describe("/v0/api/validate-directory endpoint", () => {
 
 		const response = await fetchValidator({
 			url: directoryURL,
-			turnstileToken: "token",
+			"cf-turnstile-response": "token",
 		});
 
 		expect(response.status).toEqual(502);
@@ -248,77 +224,30 @@ describe("/v0/api/validate-directory endpoint", () => {
 		});
 	});
 
-	it("rejects unusable Ed25519 keys", async () => {
-		vi.stubGlobal(
-			"fetch",
-			mockedFetch(
-				Response.json({
-					keys: [{ crv: "Ed25519", kty: "OKP" }],
-					purpose: "",
-				})
-			)
-		);
-
-		const response = await fetchValidator({
-			url: directoryURL,
-			turnstileToken: "token",
-		});
-
-		expect(response.status).toEqual(200);
-		expect(await response.json()).toEqual({
-			ok: false,
-			errors: ["keys[0].x must be a string"],
-			warnings: [],
-		});
-	});
-
-	it("rejects malformed Ed25519 key material", async () => {
-		vi.stubGlobal(
-			"fetch",
-			mockedFetch(
-				Response.json({
-					keys: [{ crv: "Ed25519", kty: "OKP", x: "abc" }],
-					purpose: "",
-				})
-			)
-		);
-
-		const response = await fetchValidator({
-			url: directoryURL,
-			turnstileToken: "token",
-		});
-
-		expect(response.status).toEqual(200);
-		expect(await response.json()).toEqual({
-			ok: false,
-			errors: ["keys[0].x must be a 32-byte base64url value"],
-			warnings: [],
-		});
-	});
-
 	it("validates a directory and warns on loose content type", async () => {
+		const directory = {
+			keys: [{}],
+			purpose: "",
+		};
 		vi.stubGlobal(
 			"fetch",
 			mockedFetch(
-				new Response(
-					JSON.stringify({
-						keys: [{ crv: "Ed25519", kty: "OKP", x: validEd25519X }],
-						purpose: "",
-					}),
-					{ headers: { "Content-Type": "text/plain" } }
-				)
+				new Response(JSON.stringify(directory), {
+					headers: { "Content-Type": "text/plain" },
+				})
 			)
 		);
 
 		const response = await fetchValidator({
 			url: directoryURL,
-			turnstileToken: "token",
+			"cf-turnstile-response": "token",
 		});
 
 		expect(response.status).toEqual(200);
 		expect(await response.json()).toEqual({
 			ok: true,
 			errors: [],
+			directory,
 			warnings: ["Directory returned unexpected Content-Type text/plain"],
 		});
 	});

--- a/examples/verification-workers/test/index.spec.ts
+++ b/examples/verification-workers/test/index.spec.ts
@@ -106,6 +106,9 @@ describe("/debug endpoint", () => {
 
 		expect(body).toContain("directory-validator");
 		expect(body).toContain("Validate key directory");
+		expect(body).toContain("Fetched directory");
+		expect(body).toContain("signatureDirectoryURL.value = directoryURL");
+		expect(body).not.toContain('data-sitekey=""');
 	});
 
 	it("renders signature header placeholders", async () => {
@@ -120,6 +123,24 @@ describe("/debug endpoint", () => {
 		expect(body).toContain("Signature");
 		expect(body).toContain("Signature-Agent");
 		expect(body).toContain("Signature-Input");
+		expect(body).toContain('parts.join("\\n")');
+	});
+});
+
+describe("/.well-known/http-message-signatures-directory endpoint", () => {
+	it("responds with a signed directory", async () => {
+		const request = new IncomingRequest(directoryURL);
+		const ctx = createExecutionContext();
+		const response = await worker.fetch(request, env, ctx);
+		await waitOnExecutionContext(ctx);
+
+		expect(response.status).toEqual(200);
+		expect(response.headers.get("content-type")).toContain(
+			"application/http-message-signatures-directory+json"
+		);
+		expect(response.headers.get("Signature")).toBeTruthy();
+		expect(response.headers.get("Signature-Input")).toBeTruthy();
+		expect(await response.json()).toMatchObject({ purpose: "rag" });
 	});
 });
 

--- a/examples/verification-workers/test/index.spec.ts
+++ b/examples/verification-workers/test/index.spec.ts
@@ -106,9 +106,23 @@ describe("/debug endpoint", () => {
 
 		expect(body).toContain("directory-validator");
 		expect(body).toContain("Validate key directory");
+		expect(body).toContain(
+			"URL path must end with <code>/.well-known/http-message-signatures-directory</code>"
+		);
 		expect(body).toContain("Fetched directory");
-		expect(body).toContain("signatureDirectoryURL.value = directoryURL");
+		expect(body).toContain("fillJWK(key)");
 		expect(body).not.toContain('data-sitekey=""');
+	});
+
+	it("renders JWK keyid tools", async () => {
+		const request = new Request(`${sampleURL}/debug`);
+		const response = await SELF.fetch(request);
+		const body = await response.text();
+
+		expect(body).toContain("Get JWK keyid");
+		expect(body).toContain("key-id-calculator");
+		expect(body).toContain("computeJWKKeyID");
+		expect(body).toContain("signatureJWK.value");
 	});
 
 	it("renders signature header placeholders", async () => {
@@ -117,12 +131,17 @@ describe("/debug endpoint", () => {
 		const body = await response.text();
 
 		expect(body).toContain("Verify request headers");
-		expect(body).toContain("Directory URL");
+		expect(body).toContain("signature-jwk");
+		expect(body).not.toContain("signature-directory-url");
 		expect(body).toContain("Method");
 		expect(body).toContain("URL");
 		expect(body).toContain("Signature");
 		expect(body).toContain("Signature-Agent");
 		expect(body).toContain("Signature-Input");
+		expect(body).toContain("Accepted forms:");
+		expect(body).toContain(
+			'Signature-Agent must be "<url>" or <label>="<url>"'
+		);
 		expect(body).toContain('parts.join("\\n")');
 	});
 });
@@ -215,6 +234,23 @@ describe("/v0/api/proxy-directory endpoint", () => {
 		expect(fetch).not.toHaveBeenCalled();
 		expect(await response.json()).toEqual({
 			error: "Directory URL must not use a custom port",
+		});
+	});
+
+	it("rejects target paths outside the directory endpoint", async () => {
+		const fetch = vi.fn();
+		vi.stubGlobal("fetch", fetch);
+
+		const response = await fetchValidator({
+			url: "https://example.com/.well-known/other",
+			"cf-turnstile-response": "token",
+		});
+
+		expect(response.status).toEqual(400);
+		expect(fetch).not.toHaveBeenCalled();
+		expect(await response.json()).toEqual({
+			error:
+				"Directory URL path must end with /.well-known/http-message-signatures-directory",
 		});
 	});
 

--- a/examples/verification-workers/test/index.spec.ts
+++ b/examples/verification-workers/test/index.spec.ts
@@ -114,6 +114,31 @@ describe("/debug endpoint", () => {
 		expect(body).not.toContain('data-sitekey=""');
 	});
 
+	it("renders section fragment tooling", async () => {
+		const request = new Request(`${sampleURL}/debug`);
+		const response = await SELF.fetch(request);
+		const body = await response.text();
+
+		expect(body).toContain("section-link");
+		expect(body).toContain('data-section="validate-directory"');
+		expect(body).toContain('data-section="get-jwk-keyid"');
+		expect(body).toContain('data-section="verify-request-headers"');
+		expect(body).toContain("fragmentParams");
+		expect(body).toContain('prefill("key-id-jwk", "key-id-jwk")');
+		expect(body).toContain('prefill("signature-jwk", "signature-jwk")');
+		expect(body).toContain('prefill("key-id-jwk", "jwk")');
+		expect(body).toContain('prefill("signature-jwk", "jwk")');
+		expect(body).toContain('["section", section]');
+		expect(body).toContain('["key-id-jwk", formValue("key-id-jwk")]');
+		expect(body).toContain('["signature-jwk", formValue("signature-jwk")]');
+		expect(body).toContain("currentSectionURL");
+		expect(body).toContain("updateSectionLink");
+		expect(body).toContain('link.addEventListener("pointerenter"');
+		expect(body).toContain('link.addEventListener("focus"');
+		expect(body).toContain("url.hash = params.toString()");
+		expect(body).toContain("history.pushState");
+	});
+
 	it("renders JWK keyid tools", async () => {
 		const request = new Request(`${sampleURL}/debug`);
 		const response = await SELF.fetch(request);
@@ -143,6 +168,10 @@ describe("/debug endpoint", () => {
 			'Signature-Agent must be "<url>" or <label>="<url>"'
 		);
 		expect(body).toContain('parts.join("\\n")');
+		expect(body).toContain('warnings.push("signature has expired")');
+		expect(body).toContain(
+			'appendMessagesTo(signatureResult, "Warnings", verification.warnings)'
+		);
 	});
 });
 

--- a/examples/verification-workers/worker-configuration.d.ts
+++ b/examples/verification-workers/worker-configuration.d.ts
@@ -5,6 +5,8 @@ declare namespace Cloudflare {
 	interface Env {
 		SIGNATURE_AGENT: "http-message-signatures-example.research.cloudflare.com";
 		TARGET_URL: "https://http-message-signatures-example.research.cloudflare.com/debug";
+		TURNSTILE_SECRET_KEY: string;
+		TURNSTILE_SITE_KEY: string;
 	}
 }
 interface Env extends Cloudflare.Env {}


### PR DESCRIPTION
Adds a dedicated `/debug` page for Web Bot Auth debugging.

<img width="853" height="816" alt="Screenshot 2026-05-26 at 12-19-00 Debug HTTP Message Signatures" src="https://github.com/user-attachments/assets/da6ab6f6-b71c-4808-bd8b-0724135a0639" />


## Changes
- Moves directory validation off the main explainer page.
- Adds `/debug` with:
  - key directory validation
  - fetched directory JSON display
  - autofill from directory validation into signature verification
  - local signature-header verification UI
- Keeps directory proxy logic out of `index.ts`.
- Fixes `/.well-known/http-message-signatures-directory` response signing.
- Makes Turnstile rendering conditional so missing site key does not break `/debug`.

## Test
- `npm run test -w verification-workers -- --run`
- `npm exec prettier -- --check ...`
- `npm exec eslint -- ...`

Closes #37 

## For the reviewer

While the behaviour mayn appear to be similar to #83, the implementation is quite distinct. The client uses a proxy only to fetch the directory data. All informations are still validated locally. We don't overload the index page. We also require a captcha to arbitrarily fetch an external directory