### PR TITLE
Document Signature-Agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,9 @@
 
 ![GitHub License](https://img.shields.io/github/license/cloudflareresearch/web-bot-auth)
 
-Repository presenting authentication for orchestrated agents navigating the web.
-It implements all components required by Web Bot Authentication defined by [draft-meunier-web-bot-auth-architecture](https://thibmeu.github.io/http-message-signatures-directory/draft-meunier-web-bot-auth-architecture.html), and presents [examples](#examples).
+This repo contains Web Bot Auth libraries and examples for signed automated HTTP traffic, as described in [draft-meunier-webbotauth-httpsig-protocol](https://datatracker.ietf.org/doc/draft-meunier-webbotauth-httpsig-protocol/).
 
-## Tables of Content
+## Table of Contents
 
 - [Examples](#examples)
 - [Development](#development)
@@ -18,11 +17,11 @@ It implements all components required by Web Bot Authentication defined by [draf
 
 Cloudflare Research provides a live environment at [http-message-signatures-example.research.cloudflare.com](https://http-message-signatures-example.research.cloudflare.com/).
 
-This deployment allows to test your implementation.
+Use this deployment to test an implementation.
 
 1. It validates the presence of a `Signature` header signed [RFC9421 ed25519 test key](./examples/rfc9421-keys/ed25519.pem),
 2. It exposes a bot directory on [/.well-known/http-message-signatures-directory](https://http-message-signatures-example.research.cloudflare.com/.well-known/http-message-signatures-directory),
-3. It provides explanation about the protocol.
+3. It serves debug tools for request signatures, JWK key IDs, and directories.
 
 ### Signing
 
@@ -41,9 +40,9 @@ This deployment allows to test your implementation.
 
 ### HTTP Signature Directories
 
-| Example                                                            | Description                                                    |
-| :----------------------------------------------------------------- | :------------------------------------------------------------- |
-| [Cloudflare Workers](./examples/signature-agent-card-and-registry) | Host a signature directory on Cloudflare Workers, using the [signature agent card and registry](https://datatracker.ietf.org/doc/draft-meunier-webbotauth-registry/) format |
+| Example                                                            | Description                                                                           |
+| :----------------------------------------------------------------- | :------------------------------------------------------------------------------------ |
+| [Cloudflare Workers](./examples/signature-agent-card-and-registry) | Host a registry, Signature Agent Card, and signed key directory on Cloudflare Workers |
 
 ## Development
 
@@ -53,8 +52,8 @@ This repository uses [npm](https://docs.npmjs.com/cli/v11/using-npm/workspaces) 
 | :------------------------------------------------------------- | :--------- | :------------------------------------------------------------------------------------- |
 | [http-message-sig](./packages/http-message-sig/)               | TypeScript | HTTP Message Signatures as defined in RFC 9421                                         |
 | [jsonwebkey-thumbprint](./packages/jsonwebkey-thumbprint/)     | TypeScript | JWK Thumbprint as defined in RFC 7638                                                  |
-| [web-bot-auth](./packages/web-bot-auth/)                       | TypeScript | HTTP Message Signatures for Bots as defined in draft-meunier-web-bot-auth-architecture |
-| [web-bot-auth](./crates/web-bot-auth/)                         | Rust       | HTTP Message Signatures for Bots as defined in draft-meunier-web-bot-auth-architecture |
+| [web-bot-auth](./packages/web-bot-auth/)                       | TypeScript | HTTP Message Signatures for Bots as defined in [draft-meunier-webbotauth-httpsig-protocol-00](https://datatracker.ietf.org/doc/draft-meunier-webbotauth-httpsig-protocol/00/) |
+| [web-bot-auth](./crates/web-bot-auth/)                         | Rust       | HTTP Message Signatures for Bots as defined in [draft-meunier-webbotauth-httpsig-protocol-00](https://datatracker.ietf.org/doc/draft-meunier-webbotauth-httpsig-protocol/00/) |
 | [http-signature-directory](./crates/http-signature-directory/) | Rust       | Validates whether an HTTP message signature directory is correctly signed and valid    |
 
 ## Security Considerations

--- a/crates/http-signature-directory/README.md
+++ b/crates/http-signature-directory/README.md
@@ -5,7 +5,7 @@
 
 [crates.io]: https://crates.io/crates/http-signature-directory
 
-A command-line tool to validate an HTTP message signatures directory per [the HTTP Message Signatures directory draft](https://www.ietf.org/archive/id/draft-meunier-http-message-signatures-directory-00.html).
+A command-line tool to validate an HTTP message signatures directory per [draft-meunier-webbotauth-httpsig-directory-00](https://datatracker.ietf.org/doc/draft-meunier-webbotauth-httpsig-directory/00/).
 
 This is an opinionated validator:
 

--- a/crates/web-bot-auth/README.md
+++ b/crates/web-bot-auth/README.md
@@ -5,9 +5,9 @@
 
 [crates.io]: https://crates.io/crates/web-bot-auth
 
-A pure Rust implementation of [web-bot-auth](https://github.com/cloudflare/web-bot-auth) as defined by [draft-meunier-web-bot-auth-architecture](https://thibmeu.github.io/http-message-signatures-directory/draft-meunier-web-bot-auth-architecture.html).
+A pure Rust implementation of [web-bot-auth](https://github.com/cloudflare/web-bot-auth) as defined by [draft-meunier-webbotauth-httpsig-protocol-00](https://datatracker.ietf.org/doc/draft-meunier-webbotauth-httpsig-protocol/00/).
 
-## Tables of Content
+## Table of Contents
 
 - [Features](#features)
 - [Usage](#usage)
@@ -18,6 +18,7 @@ A pure Rust implementation of [web-bot-auth](https://github.com/cloudflare/web-b
 
 - Plug-and-play HTTP message signature support: generate and verify signatures for any arbitrary HTTP message, independent of framework or library, by implementing the traits `UnsignedMessage` / `SignedMessage`.
 - Out-of-the-box support for verifying and generating secure `web-bot-auth` signatures specifically.
+- Parsers for `Signature-Agent`, registry files, and Signature Agent Cards.
 
 ## Usage
 

--- a/examples/browser-extension/README.md
+++ b/examples/browser-extension/README.md
@@ -3,7 +3,7 @@
 ![GitHub License](https://img.shields.io/github/license/cloudflareresearch/web-bot-auth)
 ![GitHub Release](https://img.shields.io/github/v/release/cloudflareresearch/web-bot-auth)
 
-Chrome browser extension adding HTTP Message Signature on all outgoing requests as defined by [RFC 9421](https://datatracker.ietf.org/doc/html/rfc9421). Specification is in [draft-meunier-web-bot-auth-architecture](https://thibmeu.github.io/http-message-signatures-directory/draft-meunier-web-bot-auth-architecture.html).
+Chrome browser extension adding HTTP Message Signature on all outgoing requests as defined by [RFC 9421](https://datatracker.ietf.org/doc/html/rfc9421). Specification is in [draft-meunier-webbotauth-httpsig-protocol](https://datatracker.ietf.org/doc/draft-meunier-webbotauth-httpsig-protocol/).
 
 ## Tables of Content
 

--- a/examples/caddy-plugin/README.md
+++ b/examples/caddy-plugin/README.md
@@ -3,7 +3,7 @@
 ![GitHub License](https://img.shields.io/github/license/cloudflareresearch/web-bot-auth)
 ![GitHub Release](https://img.shields.io/github/v/release/cloudflareresearch/web-bot-auth)
 
-[Caddy plugin](https://caddyserver.com/docs/extending-caddy) extending Caddy configuration to allow for validation of web-bot-auth as defined in [draft-meunier-web-bot-auth-architecture](https://thibmeu.github.io/http-message-signatures-directory/draft-meunier-web-bot-auth-architecture.html).
+[Caddy plugin](https://caddyserver.com/docs/extending-caddy) extending Caddy configuration to allow for validation of web-bot-auth as defined in [draft-meunier-webbotauth-httpsig-protocol](https://datatracker.ietf.org/doc/draft-meunier-webbotauth-httpsig-protocol/).
 
 ## Table of Contents
 

--- a/examples/rust/signing.rs
+++ b/examples/rust/signing.rs
@@ -54,14 +54,14 @@ impl UnsignedMessage for MyThing {
 }
 
 fn main() {
-    // Signing a message - private key pulled from https://datatracker.ietf.org/doc/draft-meunier-web-bot-auth-architecture/
+    // Signing a message - private key pulled from https://datatracker.ietf.org/doc/draft-meunier-webbotauth-httpsig-protocol/
     // and only for example purposes.
     let private_key = vec![
         0x9f, 0x83, 0x62, 0xf8, 0x7a, 0x48, 0x4a, 0x95, 0x4e, 0x6e, 0x74, 0x0c, 0x5b, 0x4c, 0x0e,
         0x84, 0x22, 0x91, 0x39, 0xa2, 0x0a, 0xa8, 0xab, 0x56, 0xff, 0x66, 0x58, 0x6f, 0x6a, 0x7d,
         0x29, 0xc5,
     ];
-    // sample keyid pulled from https://datatracker.ietf.org/doc/draft-meunier-web-bot-auth-architecture/
+    // sample keyid pulled from https://datatracker.ietf.org/doc/draft-meunier-webbotauth-httpsig-protocol/
     let signer = MessageSigner {
         keyid: "poqkLGiymh_W0uP6PZFw-dvez3QJT5SolqXBCW38r0U".into(),
         nonce: "ZO3/XMEZjrvSnLtAP9M7jK0WGQf3J+pbmQRUpKDhF9/jsNCWqUh2sq+TH4WTX3/GpNoSZUa8eNWMKqxWp2/c2g==".into(),

--- a/examples/rust/verify.rs
+++ b/examples/rust/verify.rs
@@ -54,7 +54,7 @@ fn main() {
         0xd1, 0xbb,
     ];
     let mut keyring = KeyRing::default();
-    // sample keyid pulled from https://datatracker.ietf.org/doc/draft-meunier-web-bot-auth-architecture/
+    // sample keyid pulled from https://datatracker.ietf.org/doc/draft-meunier-webbotauth-httpsig-protocol/
     keyring.import_raw(
         "poqkLGiymh_W0uP6PZFw-dvez3QJT5SolqXBCW38r0U".to_string(),
         Algorithm::Ed25519,

--- a/examples/signature-agent-card-and-registry/README.md
+++ b/examples/signature-agent-card-and-registry/README.md
@@ -1,14 +1,17 @@
 # Example Signature Agent Card and Registry on Cloudflare Workers
 
-This deploys a registry and a signature agent card on the same host: a Cloudflare worker.
+This deploys three endpoints on one Cloudflare Worker: a registry, a Signature Agent Card, and a signed key directory.
 
 Instructions:
 
 - `npx wrangler dev`
-- Navigate to `http://localhost:8787/.well-known/http-message-signatures-directory` to view a generated signature agent card with an example directory.
-- Navigate to `http://localhost:8787` to view a registry containing this host. Note: this will not be generated until after you've visited `/.well-known/http-message-signatures-directory`, since the card will not exist until then.
+- Visit `http://localhost:8787/signature-agent-card` to view the card.
+- Visit `http://localhost:8787/.well-known/http-message-signatures-directory` to view the signed JWKS directory.
+- Visit `http://localhost:8787/registry.txt` to view the registry. The registry entry appears after the directory endpoint has generated a key for the host.
 
-This configuration allows you to attach multiple routes and generate an SAC for each one, all viewable in the registry.
+The `http://localhost:8787` output is for development only. Registry entries, `client_id`, and `jwks_uri` are expected to use HTTPS. For local parser tests, put the Worker behind a local HTTPS proxy, for example with `mkcert`-generated certificates.
+
+Attach more routes to the Worker to generate one card per host. The registry lists each host once it has key material.
 
 ## Warning
 

--- a/examples/verification-workers/src/index-html.ts
+++ b/examples/verification-workers/src/index-html.ts
@@ -223,7 +223,7 @@ const generateHTML = (status?: boolean) => `<!DOCTYPE html>
       HTTP Message Signatures are a mechanism to create, encode, and verify signatures over components of an HTTP message.
       They are standardised by the IETF in <a href="https://datatracker.ietf.org/doc/html/rfc9421">RFC 9421</a>.
 
-      This website validates the presence of such signature as defined in <a href="https://github.com/thibmeu/http-message-signatures-directory">draft-meunier-web-bot-auth-architecture</a>.
+      This website validates the presence of such signature as defined in <a href="https://github.com/thibmeu/http-message-signatures-directory">draft-meunier-webbotauth-httpsig-protocol</a>.
     </p>
     <p>
       This website checks for an Ed25519 signature on incoming request. They should be signed by a test public key defined in <a href="https://datatracker.ietf.org/doc/html/rfc9421#name-example-ed25519-test-key">Appendix B.1.4 of RFC 9421</a>.

--- a/packages/web-bot-auth/README.md
+++ b/packages/web-bot-auth/README.md
@@ -5,9 +5,9 @@
 
 [npm]: https://www.npmjs.com/package/web-bot-auth
 
-Web Bot Authentication defined by [draft-meunier-web-bot-auth-architecture](https://thibmeu.github.io/http-message-signatures-directory/draft-meunier-web-bot-auth-architecture.html).
+TypeScript helpers for Web Bot Auth, as described in [draft-meunier-webbotauth-httpsig-protocol-00](https://datatracker.ietf.org/doc/draft-meunier-webbotauth-httpsig-protocol/00/).
 
-## Tables of Content
+## Table of Contents
 
 - [Features](#features)
 - [Usage](#usage)
@@ -18,11 +18,12 @@ Web Bot Authentication defined by [draft-meunier-web-bot-auth-architecture](http
 
 - JWK Thumbprint pre-compute
 - JWK Thumbprint when passing a hash and encoding function
+- `Signature-Agent`, registry, and Signature Agent Card parsers
 - TypeScript types
 
 ## Usage
 
-This section provides examples usage for signing and verifying web-bot-auth material.
+This section shows basic signing and verification.
 More concrete examples are provided on [cloudflareresearch/web-bot-auth/examples](https://github.com/cloudflareresearch/web-bot-auth#examples).
 
 ### Research server for debug purposes
@@ -32,11 +33,13 @@ To help debug `web-both-auth` HTTPS requests, Cloudflare Research provides a tes
 ### Signing
 
 ```typescript
-import { signatureHeaders } from "web-bot-auth";
+import { recommendedComponents, signatureHeaders } from "web-bot-auth";
 import { signerFromJWK } from "web-bot-auth/crypto";
 
-// The following simple request is going to be signed
-const request = new Request("https://example.com");
+const signatureAgent = 'sig1="https://signature-agent.test";type=directory';
+const request = new Request("https://example.com", {
+  headers: { "Signature-Agent": signatureAgent },
+});
 
 // This is a testing-only private key/public key pair described in RFC 9421 Appendix B.1.4
 // Also available at https://github.com/cloudflareresearch/web-bot-auth/blob/main/examples/rfc9421-keys/ed25519.json
@@ -54,6 +57,7 @@ const headers = await signatureHeaders(
   await signerFromJWK(RFC_9421_ED25519_TEST_KEY),
   {
     created: now,
+    components: recommendedComponents("sig1"),
     expires: new Date(now.getTime() + 300_000), // now + 5 min
   }
 );
@@ -62,6 +66,7 @@ const headers = await signatureHeaders(
 const signedRequest = new Request("https://example.com", {
   headers: {
     Signature: headers["Signature"],
+    "Signature-Agent": signatureAgent,
     "Signature-Input": headers["Signature-Input"],
   },
 });
@@ -85,6 +90,7 @@ const RFC_9421_ED25519_TEST_KEY = {
 const signedRequest = new Request("https://example.com", {
   headers: {
     Signature: headers["Signature"],
+    "Signature-Agent": signatureAgent,
     "Signature-Input": headers["Signature-Input"],
   },
 });

--- a/packages/web-bot-auth/scripts/test-vectors.ts
+++ b/packages/web-bot-auth/scripts/test-vectors.ts
@@ -1,4 +1,4 @@
-/// This script generates test vectors for https://datatracker.ietf.org/doc/draft-meunier-http-message-signatures-directory/
+/// This script generates test vectors for https://datatracker.ietf.org/doc/draft-meunier-webbotauth-httpsig-directory/
 /// and https://datatracker.ietf.org/doc/draft-meunier-webbotauth-registry/
 /// The vectors are generated in JSON format
 ///


### PR DESCRIPTION
Update the package and repo READMEs for the current Signature-Agent, registry, and card parsers.

Show the signed request example with Signature-Agent covered by key, and describe the Worker registry/card/JWKS endpoints. Note that localhost output is dev-only unless served through local HTTPS, for example with mkcert.