### PR TITLE
Update Signature-Agent examples

### DIFF
--- a/examples/browser-extension/src/background.ts
+++ b/examples/browser-extension/src/background.ts
@@ -3,6 +3,7 @@ import {
   signatureHeadersSync,
   helpers,
   jwkToKeyID,
+  recommendedComponents,
 } from "web-bot-auth";
 import _sodium from "libsodium-wrappers";
 import jwk from "../../rfc9421-keys/ed25519.json" assert { type: "json" };
@@ -14,6 +15,8 @@ jwkToKeyID(jwk, helpers.WEBCRYPTO_SHA256, helpers.BASE64URL_DECODE).then(
 );
 
 const MAX_AGE_IN_MS = 1000 * 60 * 60; // 1 hour
+const SIGNATURE_AGENT =
+  "https://http-message-signatures-example.research.cloudflare.com";
 
 class Ed25519Signer {
   public alg: Algorithm = "ed25519";
@@ -52,6 +55,11 @@ class Ed25519Signer {
 
 chrome.webRequest.onBeforeSendHeaders.addListener(
   function (details) {
+    details.requestHeaders?.push({
+      name: "Signature-Agent",
+      value: `sig1="${SIGNATURE_AGENT}";type=directory`,
+    });
+
     const request = new Request(details.url, {
       method: details.method,
       // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
@@ -59,6 +67,7 @@ chrome.webRequest.onBeforeSendHeaders.addListener(
     });
     const now = new Date();
     const headers = signatureHeadersSync(request, new Ed25519Signer(jwk), {
+      components: recommendedComponents("sig1"),
       created: now,
       expires: new Date(now.getTime() + MAX_AGE_IN_MS),
     });

--- a/examples/signature-agent-card-and-registry/src/lib.rs
+++ b/examples/signature-agent-card-and-registry/src/lib.rs
@@ -7,7 +7,7 @@ use sha2::{Digest, Sha256};
 use std::time::Duration;
 use web_bot_auth::{
     components::{CoveredComponent, DerivedComponent, HTTPField, HTTPFieldParametersSet},
-    keyring::{Algorithm, Thumbprintable},
+    keyring::{Algorithm, JSONWebKeySet, Thumbprintable},
     message_signatures::{MessageSigner, UnsignedMessage},
 };
 use worker::*;
@@ -18,7 +18,8 @@ const README: &str = r#"
 on the same authority: a Cloudflare worker.
 <h2>Instructions</h2>
 <ol>
-    <li>Navigate to <a href="/.well-known/http-message-signatures-directory"><code>/.well-known/http-message-signatures-directory</code></a> to view a generated Signature Agent card on demand.</li>
+    <li>Navigate to <a href="/signature-agent-card"><code>/signature-agent-card</code></a> to view a generated Signature Agent card.</li>
+    <li>Navigate to <a href="/.well-known/http-message-signatures-directory"><code>/.well-known/http-message-signatures-directory</code></a> to view generated key material.</li>
     <li>Navigate to <a href="/registry.txt"><code>/registry.txt</code></a> to view a generated registry linking to that Signature Agent card.</li>
 </ol>
 <h3>Customize</h3>
@@ -28,9 +29,17 @@ This will automatically populate your registry with multiple, unique entries.
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 struct SignatureAgentCard {
+    client_id: String,
     client_name: String,
     contacts: Vec<String>,
-    keys: Vec<Thumbprintable>,
+    jwks_uri: String,
+    web_bot_auth: WebBotAuthMetadata,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct WebBotAuthMetadata {
+    trigger: String,
+    purpose: String,
 }
 
 struct SignatureHeaderGenerator<'a> {
@@ -91,7 +100,7 @@ async fn fetch(req: HttpRequest, env: Env, _ctx: Context) -> Result<Response> {
                     .into_iter()
                     .map(|key| {
                         format!(
-                            "{}://{}/.well-known/http-message-signatures-directory",
+                            "{}://{}/signature-agent-card",
                             scheme.clone(),
                             key.name.clone()
                         )
@@ -99,6 +108,31 @@ async fn fetch(req: HttpRequest, env: Env, _ctx: Context) -> Result<Response> {
                     .collect::<Vec<String>>()
                     .join("\n"),
             )
+        }
+        "/signature-agent-card" => {
+            let scheme = req
+                .uri()
+                .scheme_str()
+                .ok_or(worker::Error::RouteNoDataError)?
+                .to_string();
+            let origin = format!("{}://{}", scheme, authority);
+            let card = SignatureAgentCard {
+                client_id: format!("{origin}/signature-agent-card"),
+                client_name: authority.to_string(),
+                contacts: vec!["mailto:test@example.com".to_string()],
+                jwks_uri: format!("{origin}/.well-known/http-message-signatures-directory"),
+                web_bot_auth: WebBotAuthMetadata {
+                    trigger: "fetcher".to_string(),
+                    purpose: "example".to_string(),
+                },
+            };
+            let body = serde_json::to_string(&card)
+                .map_err(|e| worker::Error::RustError(e.to_string()))?;
+            let mut response = Response::from_body(ResponseBody::Body(body.into_bytes()))?;
+            response
+                .headers_mut()
+                .set("content-type", "application/json")?;
+            Ok(response)
         }
         "/.well-known/http-message-signatures-directory" => {
             let mut rng = rand::rngs::OsRng;
@@ -126,13 +160,11 @@ async fn fetch(req: HttpRequest, env: Env, _ctx: Context) -> Result<Response> {
             };
             let thumbprint = thumbprintable.b64_thumbprint();
 
-            let card = SignatureAgentCard {
-                client_name: authority.to_string(),
-                contacts: vec!["test@example.com".to_string()],
+            let jwks = JSONWebKeySet {
                 keys: vec![thumbprintable],
             };
 
-            let body = serde_json::to_string(&card)
+            let body = serde_json::to_string(&jwks)
                 .map_err(|e| worker::Error::RustError(e.to_string()))?;
             let mut hasher = Sha256::new();
             hasher.update(&body);

--- a/examples/verification-workers/src/debug-html.ts
+++ b/examples/verification-workers/src/debug-html.ts
@@ -224,7 +224,7 @@ export const generateDebugHTML = (turnstileSiteKey: string) => `<!DOCTYPE html>
           <label for="signature-agent-header">Signature-Agent</label>
           <div class="field">
             <textarea id="signature-agent-header" name="signature-agent" placeholder='"https://example.com"'></textarea>
-            <p class="text-muted">Accepted forms: <code>"&lt;url&gt;"</code> or <code>&lt;label&gt;="&lt;url&gt;"</code>.</p>
+            <p class="text-muted">Accepted forms: <code>&lt;label&gt;="&lt;url&gt;";type=directory</code>, <code>type=jwks_uri</code>, <code>type=cimd</code>, or legacy <code>"&lt;url&gt;"</code>.</p>
           </div>
 
           <label for="signature-input-header">Signature-Input</label>
@@ -371,9 +371,9 @@ export const generateDebugHTML = (turnstileSiteKey: string) => `<!DOCTYPE html>
         return undefined;
       }
 
-      const match = value.trim().match(/^(?:[a-z*][a-z0-9_.*-]*=)?"([^"]+)"$/);
+      const match = value.trim().match(/^(?:[a-z*][a-z0-9_.*-]*=)?"([^"]+)"(?:;type=(?:directory|jwks_uri|cimd))?$/);
       if (!match) {
-        return 'Signature-Agent must be "<url>" or <label>="<url>"';
+        return 'Signature-Agent must be "<url>" or <label>="<url>" with optional type';
       }
 
       try {
@@ -524,8 +524,13 @@ export const generateDebugHTML = (turnstileSiteKey: string) => `<!DOCTYPE html>
       }
 
       const components = [];
-      for (const component of match[2].matchAll(/"([^"]+)"/g)) {
-        components.push(component[1].toLowerCase());
+      for (const component of match[2].matchAll(/"([^"]+)"((?:;[a-z*][a-z0-9_.*-]*(?:=(?:"[^"]*"|[^; ]+))?)*)/g)) {
+        const params = {};
+        for (const parameter of component[2].matchAll(/;([^=; ]+)(?:=("[^"]*"|[^; ]+))?/g)) {
+          const rawValue = parameter[2];
+          params[parameter[1]] = rawValue === undefined ? true : rawValue.startsWith('"') ? rawValue.slice(1, -1) : rawValue;
+        }
+        components.push({ name: component[1].toLowerCase(), params });
       }
       if (components.length === 0) {
         throw new Error("Signature-Input must contain at least one component");
@@ -542,8 +547,20 @@ export const generateDebugHTML = (turnstileSiteKey: string) => `<!DOCTYPE html>
       return { key: match[1], components, params, input: header.replace(/^[^=]+=/, "") };
     };
 
+    const dictionaryMemberValue = (header, key) => {
+      const prefix = key + '="';
+      for (const member of header.split(",")) {
+        const trimmed = member.trim();
+        if (trimmed.startsWith(prefix)) {
+          const end = trimmed.indexOf('"', prefix.length);
+          return end === -1 ? "" : trimmed.slice(prefix.length, end);
+        }
+      }
+      return "";
+    };
+
     const componentValue = (component, request, headers) => {
-      switch (component) {
+      switch (component.name) {
         case "@method":
           return request.method.toUpperCase();
         case "@target-uri":
@@ -561,13 +578,22 @@ export const generateDebugHTML = (turnstileSiteKey: string) => `<!DOCTYPE html>
           return request.url.pathname;
         case "@query":
           return request.url.search;
+        case "signature-agent":
+          return component.params.key === undefined
+            ? headers[component.name] || ""
+            : dictionaryMemberValue(headers[component.name] || "", component.params.key);
         default:
-          return headers[component] || "";
+          return headers[component.name] || "";
       }
     };
 
     const buildSignedData = (parsed, request, headers) => {
-      const parts = parsed.components.map((component) => '"' + component + '": ' + componentValue(component, request, headers));
+      const parts = parsed.components.map((component) => {
+        const params = Object.entries(component.params)
+          .map(([name, value]) => value === true ? ";" + name : ";" + name + '="' + value + '"')
+          .join("");
+        return '"' + component.name + '"' + params + ": " + componentValue(component, request, headers);
+      });
       parts.push('"@signature-params": ' + parsed.input);
       return parts.join("\\n");
     };

--- a/examples/verification-workers/src/index.ts
+++ b/examples/verification-workers/src/index.ts
@@ -18,12 +18,15 @@ import {
 	MediaType,
 	Signer,
 	SignatureAgentCard,
+	SignatureAgentEntry,
 	VerificationParams,
 	directoryResponseHeaders,
 	helpers,
 	jwkToKeyID,
 	parseRegistry,
 	parseSignatureAgentCard,
+	parseSignatureAgentHeader,
+	recommendedComponents,
 	signatureHeaders,
 	verify,
 } from "web-bot-auth";
@@ -35,6 +38,52 @@ import { Ed25519Signer } from "web-bot-auth/crypto";
 
 function errorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function jsonWebKeyFromUnknown(value: unknown): JsonWebKey {
+	if (!isRecord(value)) {
+		throw new Error("JWK must be an object");
+	}
+	if (typeof value.kty !== "string") {
+		throw new Error("JWK kty must be a string");
+	}
+	const key: JsonWebKey = {
+		alg: typeof value.alg === "string" ? value.alg : undefined,
+		crv: typeof value.crv === "string" ? value.crv : undefined,
+		d: typeof value.d === "string" ? value.d : undefined,
+		e: typeof value.e === "string" ? value.e : undefined,
+		kty: value.kty,
+		n: typeof value.n === "string" ? value.n : undefined,
+		x: typeof value.x === "string" ? value.x : undefined,
+		y: typeof value.y === "string" ? value.y : undefined,
+	};
+	if (Array.isArray(value.key_ops)) {
+		const keyOps: string[] = [];
+		for (const keyOp of value.key_ops) {
+			if (typeof keyOp === "string") {
+				keyOps.push(keyOp);
+			}
+		}
+		key.key_ops = keyOps;
+	}
+	if (typeof value.ext === "boolean") {
+		key.ext = value.ext;
+	}
+	return key;
+}
+
+function directoryFromUnknown(value: unknown): Directory {
+	if (!isRecord(value) || !Array.isArray(value.keys)) {
+		throw new Error("directory must contain keys");
+	}
+	return {
+		keys: value.keys.map(jsonWebKeyFromUnknown),
+		purpose: typeof value.purpose === "string" ? value.purpose : "",
+	};
 }
 
 async function getExampleDirectory(): Promise<Directory> {
@@ -83,45 +132,35 @@ function registryResponse(env: Env): Response {
 	return new Response(registry, { headers: { "content-type": "text/plain" } });
 }
 
-async function fetchDirectory(signatureAgent: string): Promise<Directory> {
-	// make "some" validatation of the Signature-Agent header before making a request
-	let parsed: string;
-	try {
-		parsed = JSON.parse(signatureAgent);
-	} catch {
-		const e = new Error(
-			`Failed to validate Signature-Agent header: ${signatureAgent}`
-		);
-		console.error(e.message);
-		throw e;
+async function fetchJSON(url: string): Promise<unknown> {
+	const response = await fetch(url);
+	if (!response.ok) {
+		throw new Error(`failed to fetch ${url}: ${response.status}`);
+	}
+	return response.json();
+}
+
+async function fetchDirectory(entry: SignatureAgentEntry): Promise<Directory> {
+	if (entry.type === "directory") {
+		const origin = new URL(entry.uri).origin;
+		const directoryURL = `${origin}${HTTP_MESSAGE_SIGNATURES_DIRECTORY}`;
+		console.log(`Fetching Signature-Agent directory from: ${directoryURL}`);
+		return directoryFromUnknown(await fetchJSON(directoryURL));
 	}
 
-	try {
-		const url = new URL(parsed);
-		if (url.protocol !== "https:") {
-			throw new Error(
-				'The demo only supports "https:" scheme for Signature-Agent header'
-			);
-		}
-		if (url.pathname !== "/") {
-			throw new Error(
-				`Only support signature-agent at the root, got "${url.pathname}"`
-			);
-		}
-	} catch (e) {
-		console.error(
-			`Failed to validate Signature-Agent header: ${signatureAgent}`
-		);
-		throw e;
+	if (entry.type === "jwks_uri") {
+		console.log(`Fetching Signature-Agent JWKS from: ${entry.uri}`);
+		return directoryFromUnknown(await fetchJSON(entry.uri));
 	}
-	if (parsed.endsWith("/")) {
-		parsed = parsed.slice(0, -1);
+
+	const card = parseSignatureAgentCard(await fetchJSON(entry.uri), entry.uri);
+	if (card.jwks !== undefined) {
+		return { keys: card.jwks.keys, purpose: "" };
 	}
-	console.log(
-		`Fetching \`Signature-Agent\` directory from: "${parsed}${HTTP_MESSAGE_SIGNATURES_DIRECTORY}"`
-	);
-	const response = await fetch(`${parsed}${HTTP_MESSAGE_SIGNATURES_DIRECTORY}`);
-	return response.json();
+	if (card.jwks_uri === undefined) {
+		throw new Error("signature agent card must contain jwks or jwks_uri");
+	}
+	return directoryFromUnknown(await fetchJSON(card.jwks_uri));
 }
 
 async function getSigner(): Promise<Signer> {
@@ -178,8 +217,17 @@ async function verifySignature(
 	const signatureAgent = request.headers.get("Signature-Agent");
 	let directory: Directory;
 	try {
-		if (signatureAgent && !signatureAgent.includes(env.SIGNATURE_AGENT)) {
-			directory = await fetchDirectory(signatureAgent);
+		if (signatureAgent) {
+			const parsed = parseSignatureAgentHeader(signatureAgent);
+			const entry = parsed.entries[0];
+			if (entry === undefined) {
+				throw new Error("Signature-Agent header has no entries");
+			}
+			if (new URL(entry.uri).origin === new URL(env.SIGNATURE_AGENT).origin) {
+				directory = await getExampleDirectory();
+			} else {
+				directory = await fetchDirectory(entry);
+			}
 		} else {
 			directory = await getExampleDirectory();
 		}
@@ -270,11 +318,14 @@ export default {
 	// On a schedule, send a web-bot-auth signed request to a target endpoint
 	async scheduled(ctx, env, ectx) {
 		void ectx;
-		const headers = { "Signature-Agent": JSON.stringify(env.SIGNATURE_AGENT) };
+		const headers = {
+			"Signature-Agent": `sig1="${env.SIGNATURE_AGENT}";type=directory`,
+		};
 		const request = new Request(env.TARGET_URL, { headers });
 		const created = new Date(ctx.scheduledTime);
 		const expires = new Date(created.getTime() + 300_000);
 		const signedHeaders = await signatureHeaders(request, await getSigner(), {
+			components: recommendedComponents("sig1"),
 			created,
 			expires,
 		});

--- a/examples/verification-workers/test/index.spec.ts
+++ b/examples/verification-workers/test/index.spec.ts
@@ -165,9 +165,7 @@ describe("/debug endpoint", () => {
 		expect(body).toContain("Signature-Agent");
 		expect(body).toContain("Signature-Input");
 		expect(body).toContain("Accepted forms:");
-		expect(body).toContain(
-			'Signature-Agent must be "<url>" or <label>="<url>"'
-		);
+		expect(body).toContain('&lt;label&gt;="&lt;url&gt;";type=directory');
 		expect(body).toContain('parts.join("\\n")');
 		expect(body).toContain('warnings.push("signature has expired")');
 		expect(body).toContain(


### PR DESCRIPTION
Switch the browser extension and scheduled Worker request to the current Signature-Agent dictionary syntax.

Sign the selected Signature-Agent member with signature-agent;key=... so the examples match the protocol parser.

Update the Worker verifier and debug page to read typed Signature-Agent entries (while keeping the existing registry, card, and IP endpoints in place).