### PR TITLE
Fix clippy 1.97 useless_borrows_in_formatting lint

### DIFF
--- a/crates/web-bot-auth/src/components.rs
+++ b/crates/web-bot-auth/src/components.rs
@@ -217,7 +217,7 @@ impl TryFrom<HTTPField> for sfv::Item {
     fn try_from(value: HTTPField) -> Result<Self, Self::Error> {
         let error_message_fragment = format!(
             "Could not coerce HTTP field name `{}` into a valid sfv Item: ",
-            &value.name
+            value.name
         );
 
         Ok(sfv::Item {
@@ -380,7 +380,7 @@ impl TryFrom<QueryParamParametersSet> for sfv::Parameters {
                     let value = sfv::String::from_string(name.clone())
                         .map_err(|(_, s)| ImplementationError::ParsingError(format!(
                             "Could not coerce `@query-param` parameter `{}` into a valid sfv Parameter: {}",
-                            &name, s
+                            name, s
                         )))?;
                     sfv_parameters.insert(key, sfv::BareItem::String(value));
                     name_seen = true;


### PR DESCRIPTION
Rust 1.97's clippy added `useless_borrows_in_formatting`, which flags two redundant `&` references in `format!` arguments in `crates/web-bot-auth/src/components.rs`. Since CI runs `cargo clippy -- -D warnings` on stable, this fails the Test Rust job on every PR (e.g. #109, which is otherwise unrelated).

This removes the two redundant borrows. `cargo clippy --all-features --all-targets -- -D warnings` passes locally on 1.97.