### PR TITLE
Fix RFC 9421 authority port normalization

### DIFF
--- a/crates/web-bot-auth/src/message_signatures.rs
+++ b/crates/web-bot-auth/src/message_signatures.rs
@@ -765,4 +765,28 @@ mod tests {
         let (base, _) = sigbase.into_ascii().unwrap();
         assert_eq!(base, expected_base);
     }
+
+    #[test]
+    fn signature_base_preserves_percent_encoded_components() {
+        let sigbase = SignatureBase {
+            components: IndexMap::from_iter([
+                (
+                    CoveredComponent::Derived(DerivedComponent::Path { req: false }),
+                    "/%7Esmith".to_string(),
+                ),
+                (
+                    CoveredComponent::Derived(DerivedComponent::Query { req: false }),
+                    "?baz=bat%7Eman".to_string(),
+                ),
+            ]),
+            parameters: IndexMap::new().into(),
+        };
+
+        // RFC 9421 sections 2.2.6 and 2.2.7 use values before percent-decoding.
+        let (base, _) = sigbase.into_ascii().unwrap();
+        assert_eq!(
+            base,
+            "\"@path\": /%7Esmith\n\"@query\": ?baz=bat%7Eman\n\"@signature-params\": (\"@path\" \"@query\")"
+        );
+    }
 }

--- a/examples/verification-workers/src/debug-html.ts
+++ b/examples/verification-workers/src/debug-html.ts
@@ -565,11 +565,8 @@ export const generateDebugHTML = (turnstileSiteKey: string) => `<!DOCTYPE html>
           return request.method.toUpperCase();
         case "@target-uri":
           return request.url.toString();
-        case "@authority": {
-          const port = request.url.port;
-          const includePort = port !== "" && port !== "80" && port !== "443";
-          return request.url.hostname + (includePort ? ":" + port : "");
-        }
+        case "@authority":
+          return request.url.host;
         case "@scheme":
           return request.url.protocol.slice(0, -1);
         case "@request-target":

--- a/packages/http-message-sig/src/build.ts
+++ b/packages/http-message-sig/src/build.ts
@@ -86,11 +86,9 @@ export function extractComponent(
       if (!(message as RequestLike).url)
         throw new Error(`${component} is only valid for requests`);
       return (message as RequestLike).url;
-    case "@authority": {
-      const url = getUrl(message, component);
-      const port = url.port ? parseInt(url.port, 10) : null;
-      return `${url.hostname}${port && ![80, 443].includes(port) ? `:${port}` : ""}`;
-    }
+    case "@authority":
+      // URL.host omits only the scheme's default port, per RFC 9421 section 2.2.3.
+      return getUrl(message, component).host;
     case "@scheme":
       return getUrl(message, component).protocol.slice(0, -1);
     case "@request-target": {

--- a/packages/http-message-sig/test/build.spec.ts
+++ b/packages/http-message-sig/test/build.spec.ts
@@ -84,6 +84,18 @@ describe("build", () => {
       expect(result).to.equal("www.example.com");
     });
 
+    it.each([
+      ["http://www.example.com:443/", "www.example.com:443"],
+      ["https://www.example.com:80/", "www.example.com:80"],
+      ["http://www.example.com:80/", "www.example.com"],
+    ])("normalizes @authority for %s", (url, expected) => {
+      const result = extractComponent(
+        { method: "GET", url } as unknown as RequestLike,
+        "@authority"
+      );
+      expect(result).to.equal(expected);
+    });
+
     it("correctly extracts the @scheme", () => {
       const result = extractComponent(
         {
@@ -117,6 +129,18 @@ describe("build", () => {
       expect(result).to.equal("/path");
     });
 
+    it.each([
+      ["https://www.example.com/%7epath", "/%7epath"],
+      ["https://www.example.com/%zz", "/%zz"],
+    ])("does not percent-decode @path for %s", (url, expected) => {
+      // RFC 9421 section 2.2.6 uses values before percent-decoding.
+      const result = extractComponent(
+        { method: "GET", url } as unknown as RequestLike,
+        "@path"
+      );
+      expect(result).to.equal(expected);
+    });
+
     it("correctly extracts the @query", () => {
       const result = extractComponent(
         {
@@ -126,6 +150,18 @@ describe("build", () => {
         "@query"
       );
       expect(result).to.equal("?param=value&foo=bar&baz=batman");
+    });
+
+    it("does not percent-decode @query", () => {
+      // RFC 9421 section 2.2.7 requires percent-encoded octets to remain encoded.
+      const result = extractComponent(
+        {
+          method: "GET",
+          url: "https://www.example.com/path?param=value&foo=bar&baz=bat%2Dman",
+        } as unknown as RequestLike,
+        "@query"
+      );
+      expect(result).to.equal("?param=value&foo=bar&baz=bat%2Dman");
     });
 
     it("correctly extracts the @query string", () => {


### PR DESCRIPTION
Closes #54 and #55

in rust, it ensures that percent encoding is preserved
in typescript, it matches [RFC 9421 section 2.2.3](https://www.rfc-editor.org/info/rfc9421/#section-2.2.3) `the default port is omitted`. It adds a dedicated regression test there.