### PR TITLE
test: add signed directory response vector

### DIFF
--- a/packages/http-message-sig/src/directory.ts
+++ b/packages/http-message-sig/src/directory.ts
@@ -12,6 +12,7 @@ export const RESPONSE_COMPONENTS: Component[] = [
     name: "@authority",
     parameters: new Map([["req", true]]),
   },
+  "content-digest",
 ];
 
 export interface SignatureParams {

--- a/packages/http-message-sig/test/directory.spec.ts
+++ b/packages/http-message-sig/test/directory.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { directoryResponseHeaders, Signer } from "../src";
+
+describe("directoryResponseHeaders", () => {
+  it("binds the response body to the request authority", async () => {
+    const created = new Date(1735689600000);
+    const expires = new Date(4889289600000);
+    const signature = new Uint8Array([1, 2, 3]);
+    const signer: Signer = {
+      keyid: "test-key",
+      alg: "ed25519",
+      async sign(data) {
+        expect(data).toBe(
+          [
+            '"@authority";req: signature-agent.test',
+            '"content-digest": sha-256=:test-digest:',
+            '"@signature-params": ("@authority";req "content-digest");created=1735689600;keyid="test-key";alg="ed25519";expires=4889289600;tag="http-message-signatures-directory"',
+          ].join("\n")
+        );
+        return signature;
+      },
+    };
+
+    const headers = await directoryResponseHeaders(
+      {
+        request: {
+          method: "GET",
+          url: "https://signature-agent.test/.well-known/http-message-signatures-directory",
+          headers: {},
+        },
+        response: {
+          status: 200,
+          headers: { "content-digest": "sha-256=:test-digest:" },
+        },
+      },
+      [signer],
+      { created, expires }
+    );
+
+    expect(headers["Signature-Input"]).toBe(
+      'binding0=("@authority";req "content-digest");created=1735689600;keyid="test-key";alg="ed25519";expires=4889289600;tag="http-message-signatures-directory"'
+    );
+    expect(headers.Signature).toBe("binding0=:AQID:");
+  });
+});

--- a/packages/web-bot-auth/package.json
+++ b/packages/web-bot-auth/package.json
@@ -33,7 +33,7 @@
   },
   "scripts": {
     "build": "tsdown src/index.ts src/crypto.ts --format esm,cjs --target es2021",
-    "generate-test-vectors": "npm run build && node scripts/test-vectors.ts test/test_data",
+    "generate-test-vectors": "npm run build -w http-message-sig && npm run build && node scripts/test-vectors.ts test/test_data",
     "prepublishOnly": "npm run build",
     "test": "vitest",
     "watch": "npm run build -- --watch src"

--- a/packages/web-bot-auth/scripts/test-vectors.ts
+++ b/packages/web-bot-auth/scripts/test-vectors.ts
@@ -4,10 +4,14 @@
 ///
 /// It takes one positional argument: [directory] which is where the vectors should be written in JSON
 
+import type { Signer } from "http-message-sig";
+
 const { recommendedComponents, signatureHeaders } =
   await import("../dist/index.mjs");
 
 const { signerFromJWK } = await import("../dist/crypto.mjs");
+
+const { directoryResponseHeaders } = await import("http-message-sig");
 
 const crypto = await import("crypto");
 const fs = await import("fs");
@@ -68,6 +72,28 @@ interface SignatureAgentCardVector {
   error?: string;
 }
 
+interface DirectoryResponseVector {
+  name: string;
+  public_key: {
+    kty: "OKP";
+    crv: "Ed25519";
+    kid: string;
+    x: string;
+    use: "sig";
+  };
+  request: {
+    method: "GET";
+    target_url: string;
+    headers: Record<string, string>;
+  };
+  response: {
+    status: 200;
+    headers: Record<string, string>;
+    body: string;
+  };
+  signature_base: string;
+}
+
 async function generateTestVectors(jwk: JsonWebKey): Promise<TestVector[]> {
   const now = new Date("2025-01-01T00:00:00Z");
   const created = now;
@@ -126,6 +152,75 @@ async function generateTestVectors(jwk: JsonWebKey): Promise<TestVector[]> {
       signature_agent_key: signatureAgentKey,
     },
   ];
+}
+
+async function generateDirectoryResponseVector(
+  jwk: JsonWebKey
+): Promise<DirectoryResponseVector> {
+  if (jwk.kty !== "OKP" || jwk.crv !== "Ed25519" || !jwk.x) {
+    throw new Error("directory response vector requires an Ed25519 JWK");
+  }
+
+  const signer = await signerFromJWK(jwk);
+  const publicKey: DirectoryResponseVector["public_key"] = {
+    kty: "OKP",
+    crv: "Ed25519",
+    kid: signer.keyid,
+    x: jwk.x,
+    use: "sig",
+  };
+  const body = JSON.stringify({ keys: [publicKey] });
+  const contentDigest = `sha-256=:${crypto.createHash("sha256").update(body).digest("base64")}:`;
+  const request = {
+    method: "GET",
+    url: "https://signature-agent.test/.well-known/http-message-signatures-directory",
+    headers: {
+      accept: "application/http-message-signatures-directory+json",
+    },
+  };
+  const response = {
+    status: 200,
+    headers: {
+      "content-type": "application/http-message-signatures-directory+json",
+      "content-digest": contentDigest,
+    },
+  };
+  let signatureBase: string | undefined;
+  const capturingSigner: Signer = {
+    keyid: signer.keyid,
+    alg: signer.alg,
+    async sign(data) {
+      signatureBase = data;
+      return signer.sign(data);
+    },
+  };
+  const signatureHeaders = await directoryResponseHeaders(
+    { request, response },
+    [capturingSigner],
+    {
+      created: new Date(1735689600000),
+      expires: new Date(4889289600000),
+    }
+  );
+  if (signatureBase === undefined) {
+    throw new Error("directory response was not signed");
+  }
+
+  return {
+    name: "ed25519",
+    public_key: publicKey,
+    request: {
+      method: "GET",
+      target_url: request.url,
+      headers: request.headers,
+    },
+    response: {
+      status: 200,
+      headers: { ...response.headers, ...signatureHeaders },
+      body,
+    },
+    signature_base: signatureBase,
+  };
 }
 
 const signatureAgentVectors: SignatureAgentVector[] = [
@@ -267,6 +362,9 @@ const vectors = [
   ...(await generateTestVectors(jwks.rsapss)),
   ...(await generateTestVectors(jwks.ed25519)),
 ];
+const directoryResponseVectors = [
+  await generateDirectoryResponseVector(jwks.ed25519),
+];
 
 for (const vector of vectors) {
   console.log(`Signature base
@@ -308,6 +406,10 @@ const writeVectors = (fileName: string, value: unknown) => {
 };
 
 writeVectors("web_bot_auth_architecture_v2.json", vectors);
+writeVectors(
+  "web_bot_auth_directory_response_v1.json",
+  directoryResponseVectors
+);
 writeVectors("web_bot_auth_signature_agent_v1.json", signatureAgentVectors);
 writeVectors("web_bot_auth_registry_v1.json", registryVectors);
 writeVectors("web_bot_auth_signature_agent_card_v1.json", cardVectors);

--- a/packages/web-bot-auth/test/directory-response.test.ts
+++ b/packages/web-bot-auth/test/directory-response.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { verify } from "http-message-sig";
+
+import { u8ToB64 } from "../src/base64";
+import { verifierFromJWK } from "../src/crypto";
+import vectors from "./test_data/web_bot_auth_directory_response_v1.json";
+
+describe.each(vectors)("directory response vector: $name", (vector) => {
+  it("has a valid content digest and signature", async () => {
+    const digest = await crypto.subtle.digest(
+      "SHA-256",
+      new TextEncoder().encode(vector.response.body)
+    );
+    expect(vector.response.headers["content-digest"]).toBe(
+      `sha-256=:${u8ToB64(new Uint8Array(digest))}:`
+    );
+
+    const request = {
+      method: vector.request.method,
+      url: vector.request.target_url,
+      headers: new Headers(vector.request.headers),
+    };
+    const response = {
+      status: vector.response.status,
+      headers: new Headers(vector.response.headers),
+    };
+
+    await expect(
+      verify({ request, response }, await verifierFromJWK(vector.public_key))
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/web-bot-auth/test/test_data/web_bot_auth_directory_response_v1.json
+++ b/packages/web-bot-auth/test/test_data/web_bot_auth_directory_response_v1.json
@@ -1,0 +1,30 @@
+[
+  {
+    "name": "ed25519",
+    "public_key": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "kid": "poqkLGiymh_W0uP6PZFw-dvez3QJT5SolqXBCW38r0U",
+      "x": "JrQLj5P_89iXES9-vFgrIy29clF9CC_oPPsw3c5D0bs",
+      "use": "sig"
+    },
+    "request": {
+      "method": "GET",
+      "target_url": "https://signature-agent.test/.well-known/http-message-signatures-directory",
+      "headers": {
+        "accept": "application/http-message-signatures-directory+json"
+      }
+    },
+    "response": {
+      "status": 200,
+      "headers": {
+        "content-type": "application/http-message-signatures-directory+json",
+        "content-digest": "sha-256=:CADMT2aBdV/rqQr/NIru64ERQkCobVvllA4V0fLFDu0=:",
+        "Signature": "binding0=:yiHq0TXrbpzbmlttAQMpYoAufitFJUWuNsakB7QQMoN0EHbo5o51bZRVR8az/ptTWCwllix9clrKXfGKwdPzBg==:",
+        "Signature-Input": "binding0=(\"@authority\";req \"content-digest\");created=1735689600;keyid=\"poqkLGiymh_W0uP6PZFw-dvez3QJT5SolqXBCW38r0U\";alg=\"ed25519\";expires=4889289600;tag=\"http-message-signatures-directory\""
+      },
+      "body": "{\"keys\":[{\"kty\":\"OKP\",\"crv\":\"Ed25519\",\"kid\":\"poqkLGiymh_W0uP6PZFw-dvez3QJT5SolqXBCW38r0U\",\"x\":\"JrQLj5P_89iXES9-vFgrIy29clF9CC_oPPsw3c5D0bs\",\"use\":\"sig\"}]}"
+    },
+    "signature_base": "\"@authority\";req: signature-agent.test\n\"content-digest\": sha-256=:CADMT2aBdV/rqQr/NIru64ERQkCobVvllA4V0fLFDu0=:\n\"@signature-params\": (\"@authority\";req \"content-digest\");created=1735689600;keyid=\"poqkLGiymh_W0uP6PZFw-dvez3QJT5SolqXBCW38r0U\";alg=\"ed25519\";expires=4889289600;tag=\"http-message-signatures-directory\""
+  }
+]


### PR DESCRIPTION
Reproduces the test vector generation that is proposed in https://github.com/thibmeu/http-message-signatures-directory/pull/121/, and cross validate them

TLDR: it works