### PR TITLE
Use package-specific npm release tags

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -3,7 +3,9 @@ name: Publish npm
 on:
   push:
     tags:
-      - "v*"
+      - "http-message-sig@*"
+      - "jsonwebkey-thumbprint@*"
+      - "web-bot-auth@*"
 
 permissions:
   id-token: write
@@ -24,11 +26,20 @@ jobs:
       - run: npm run build
       - run: npm run test
 
-      - run: npm publish -w http-message-sig --access public
-        continue-on-error: true
+      - name: Publish http-message-sig
+        if: startsWith(github.ref_name, 'http-message-sig@')
+        run: |
+          test "${GITHUB_REF_NAME#*@}" = "$(node -p "require('./packages/http-message-sig/package.json').version")"
+          npm publish -w http-message-sig --access public
 
-      - run: npm publish -w jsonwebkey-thumbprint --access public
-        continue-on-error: true
+      - name: Publish jsonwebkey-thumbprint
+        if: startsWith(github.ref_name, 'jsonwebkey-thumbprint@')
+        run: |
+          test "${GITHUB_REF_NAME#*@}" = "$(node -p "require('./packages/jsonwebkey-thumbprint/package.json').version")"
+          npm publish -w jsonwebkey-thumbprint --access public
 
-      - run: npm publish -w web-bot-auth --access public
-        continue-on-error: true
+      - name: Publish web-bot-auth
+        if: startsWith(github.ref_name, 'web-bot-auth@')
+        run: |
+          test "${GITHUB_REF_NAME#*@}" = "$(node -p "require('./packages/web-bot-auth/package.json').version")"
+          npm publish -w web-bot-auth --access public


### PR DESCRIPTION
Improve trusted publisher publication pipeline for npm packages

Only trigger the relevant packages, with specific tags